### PR TITLE
feat: add detailed benchmark failure diagnostics

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -23,6 +23,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import itertools
 import json
 import os
 import shutil
@@ -255,6 +256,15 @@ def _run_single(
         functional_ok = semantic_skipped or (semantic is True)
         success = run_result.success and schema_ok and functional_ok
 
+        # Include YAML preview on failure for diagnostics
+        yaml_preview = None
+        if not success and output_path.exists():
+            try:
+                with output_path.open(encoding="utf-8", errors="replace") as fh:
+                    yaml_preview = "".join(itertools.islice(fh, 25))
+            except OSError:
+                pass
+
         timestamp_str = datetime.now(timezone.utc).isoformat()
         last_result = {
             "run_id": f"run_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}_{tool_name}_{policy_id}",
@@ -279,12 +289,32 @@ def _run_single(
             "max_attempts": max_attempts,
             **eval_result,
             "error": run_result.error if not run_result.success else None,
+            "yaml_preview": yaml_preview,
         }
 
         if success or attempt == max_attempts:
             break
 
     return last_result
+
+
+def _failure_detail(result: dict) -> str:
+    """Build a short diagnostic suffix for failed runs."""
+    parts: list[str] = []
+    gvk = result.get("generated_kind") or result.get("generated_api_version")
+    if gvk:
+        api = result.get("generated_api_version", "")
+        kind = result.get("generated_kind", "")
+        parts.append(f"got {api}/{kind}" if api else f"got {kind}")
+    stage = result.get("validation_stage")
+    if stage and stage != "passed":
+        parts.append(f"stage={stage}")
+    errs = result.get("schema_errors") or result.get("error")
+    if isinstance(errs, list) and errs:
+        parts.append(errs[0][:80])
+    elif isinstance(errs, str):
+        parts.append(errs[:80])
+    return f"  ({'; '.join(parts)})" if parts else ""
 
 
 def _print_summary(results: list[dict]) -> None:
@@ -445,7 +475,10 @@ def main() -> int:
                 tool_results.append(result)
 
                 status = "PASS" if result.get("success") else "FAIL"
-                lines.append(f"  [{tool_name}] {label} ... {status}")
+                detail = ""
+                if not result.get("success"):
+                    detail = _failure_detail(result)
+                lines.append(f"  [{tool_name}] {label} ... {status}{detail}")
 
                 run_id = result.get("run_id", f"run_{tool_name}_{policy['id']}")
                 out_json = results_dir / f"{run_id}.json"
@@ -476,7 +509,10 @@ def main() -> int:
                     tool_results.append(result)
 
                     status = "PASS" if result.get("success") else "FAIL"
-                    lines.append(f"  [{completed}/{total}] [{tool_name}] {label} ... {status}")
+                    detail = ""
+                    if not result.get("success"):
+                        detail = _failure_detail(result)
+                    lines.append(f"  [{completed}/{total}] [{tool_name}] {label} ... {status}{detail}")
 
                     run_id = result.get("run_id", f"run_{tool_name}_{policy['id']}")
                     out_json = results_dir / f"{run_id}.json"

--- a/cmd/validate-policy/main.go
+++ b/cmd/validate-policy/main.go
@@ -11,12 +11,13 @@ import (
 )
 
 type Result struct {
-	SchemaPass bool     `json:"schema_pass"`
-	CELPass    bool     `json:"cel_pass"`
-	Errors     []string `json:"errors"`
-	PolicyName string   `json:"policy_name"`
-	PolicyKind string   `json:"policy_kind"`
-	APIVersion string   `json:"api_version"`
+	SchemaPass      bool     `json:"schema_pass"`
+	CELPass         bool     `json:"cel_pass"`
+	Errors          []string `json:"errors"`
+	PolicyName      string   `json:"policy_name"`
+	PolicyKind      string   `json:"policy_kind"`
+	APIVersion      string   `json:"api_version"`
+	ValidationStage string   `json:"validation_stage"`
 }
 
 func main() {
@@ -59,10 +60,11 @@ func main() {
 		APIVersion: apiVersion,
 	}
 
-	schemaPass, celPass, errs := validatePolicy(data)
+	schemaPass, celPass, errs, stage := validatePolicy(data)
 	result.SchemaPass = schemaPass
 	result.CELPass = celPass
 	result.Errors = errs
+	result.ValidationStage = stage
 	if result.Errors == nil {
 		result.Errors = []string{}
 	}

--- a/cmd/validate-policy/validate.go
+++ b/cmd/validate-policy/validate.go
@@ -43,12 +43,12 @@ var (
 
 )
 
-func validatePolicy(policyBytes []byte) (bool, bool, []string) {
+func validatePolicy(policyBytes []byte) (bool, bool, []string, string) {
 	ctrl.SetLogger(logr.Discard())
 
 	schemaFS, err := SchemaFiles()
 	if err != nil {
-		return false, false, []string{fmt.Sprintf("failed to load schemas: %v", err)}
+		return false, false, []string{fmt.Sprintf("failed to load schemas: %v", err)}, "schema_load"
 	}
 
 	ldr, err := loader.New(
@@ -57,12 +57,23 @@ func validatePolicy(policyBytes []byte) (bool, bool, []string) {
 		),
 	)
 	if err != nil {
-		return false, false, []string{fmt.Sprintf("failed to create loader: %v", err)}
+		return false, false, []string{fmt.Sprintf("failed to create loader: %v", err)}, "loader_init"
 	}
 
 	gvk, object, err := ldr.Load(policyBytes)
 	if err != nil {
-		return false, false, []string{fmt.Sprintf("schema validation failed: %v", err)}
+		// Classify failure by inspecting error text from kubectl-validate/loader.
+		// These substrings are not a stable API — update if upstream wording changes.
+		stage := "schema_validation"
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "failed to parse document") {
+			if strings.Contains(errMsg, "failed to retrieve validator") {
+				stage = "schema_lookup"
+			} else {
+				stage = "yaml_parse"
+			}
+		}
+		return false, false, []string{fmt.Sprintf("schema validation failed: %v", err)}, stage
 	}
 
 	switch gvk {
@@ -70,69 +81,69 @@ func validatePolicy(policyBytes []byte) (bool, bool, []string) {
 	case vpolV1alpha1, vpolV1beta1, vpolV1:
 		typed, err := convert.To[policiesv1beta1.ValidatingPolicy](object)
 		if err != nil {
-			return true, false, []string{fmt.Sprintf("type conversion failed: %v", err)}
+			return true, false, []string{fmt.Sprintf("type conversion failed: %v", err)}, "type_conversion"
 		}
 		if errs := checkVpolMessageExpressions(typed); len(errs) > 0 {
-			return true, false, errs
+			return true, false, errs, "cel_compile"
 		}
 		compiler := vpolcompiler.NewCompiler()
 		_, errorList := compiler.Compile(typed, nil)
 		if errorList != nil {
 			if err := errorList.ToAggregate(); err != nil {
-				return true, false, []string{fmt.Sprintf("CEL compilation failed: %v", err)}
+				return true, false, []string{fmt.Sprintf("CEL compilation failed: %v", err)}, "cel_compile"
 			}
 		}
-		return true, true, nil
+		return true, true, nil, "passed"
 
 	case mpolV1alpha1, mpolV1beta1, mpolV1:
 		typed, err := convert.To[policiesv1beta1.MutatingPolicy](object)
 		if err != nil {
-			return true, false, []string{fmt.Sprintf("type conversion failed: %v", err)}
+			return true, false, []string{fmt.Sprintf("type conversion failed: %v", err)}, "type_conversion"
 		}
 		compiler := mpolcompiler.NewCompiler()
 		_, errorList := compiler.Compile(typed, nil)
 		if errorList != nil {
 			if err := errorList.ToAggregate(); err != nil {
-				return true, false, []string{fmt.Sprintf("CEL compilation failed: %v", err)}
+				return true, false, []string{fmt.Sprintf("CEL compilation failed: %v", err)}, "cel_compile"
 			}
 		}
-		return true, true, nil
+		return true, true, nil, "passed"
 
 	case gpolV1alpha1, gpolV1beta1, gpolV1:
 		typed, err := convert.To[policiesv1beta1.GeneratingPolicy](object)
 		if err != nil {
-			return true, false, []string{fmt.Sprintf("type conversion failed: %v", err)}
+			return true, false, []string{fmt.Sprintf("type conversion failed: %v", err)}, "type_conversion"
 		}
 		compiler := gpolcompiler.NewCompiler()
 		_, errorList := compiler.Compile(typed, nil)
 		if errorList != nil {
 			if err := errorList.ToAggregate(); err != nil {
-				return true, false, []string{fmt.Sprintf("CEL compilation failed: %v", err)}
+				return true, false, []string{fmt.Sprintf("CEL compilation failed: %v", err)}, "cel_compile"
 			}
 		}
-		return true, true, nil
+		return true, true, nil, "passed"
 
 	case dpolV1alpha1, dpolV1beta1, dpolV1, ndpolV1alpha1, ndpolV1beta1, ndpolV1:
 		typed, err := convert.To[policiesv1beta1.DeletingPolicy](object)
 		if err != nil {
-			return true, false, []string{fmt.Sprintf("type conversion failed: %v", err)}
+			return true, false, []string{fmt.Sprintf("type conversion failed: %v", err)}, "type_conversion"
 		}
 		compiler := dpolcompiler.NewCompiler()
 		_, errorList := compiler.Compile(typed, nil)
 		if errorList != nil {
 			if err := errorList.ToAggregate(); err != nil {
-				return true, false, []string{fmt.Sprintf("CEL compilation failed: %v", err)}
+				return true, false, []string{fmt.Sprintf("CEL compilation failed: %v", err)}, "cel_compile"
 			}
 		}
-		return true, true, nil
+		return true, true, nil, "passed"
 
 	case ivpolV1alpha1, ivpolV1beta1, ivpolV1:
 		// ivpol CEL compilation requires ImageContext + SecretLister fakes.
 		// Schema passed via loader; CEL not tested.
-		return true, false, []string{"ImageValidatingPolicy CEL compilation not yet supported"}
+		return true, false, []string{"ImageValidatingPolicy CEL compilation not yet supported"}, "cel_compile"
 	}
 
-	return false, false, []string{fmt.Sprintf("unknown or unsupported policy type: %s", gvk.String())}
+	return false, false, []string{fmt.Sprintf("unknown or unsupported policy type: %s", gvk.String())}, "unknown_gvk"
 }
 
 func checkVpolMessageExpressions(typed *policiesv1beta1.ValidatingPolicy) []string {

--- a/evaluators/evaluate.py
+++ b/evaluators/evaluate.py
@@ -74,6 +74,12 @@ def evaluate(
         schema_pass = go_result["schema_pass"] and go_result["cel_pass"]
         schema_errors = list(go_result.get("errors", []))
 
+        # Propagate generated policy identity for diagnostics
+        result["generated_api_version"] = go_result.get("api_version", "")
+        result["generated_kind"] = go_result.get("policy_kind", "")
+        result["generated_name"] = go_result.get("policy_name", "")
+        result["validation_stage"] = go_result.get("validation_stage", "")
+
         if schema_pass and expected_output_kind:
             actual_kind = go_result.get("policy_kind", "")
             allowed = {expected_output_kind}
@@ -86,9 +92,28 @@ def evaluate(
                 )
     else:
         result["validator_used"] = "python_fallback"
-        schema_pass, schema_errors = validate_schema(
+        schema_pass, schema_errors, parsed_doc = validate_schema(
             output_path, expected_kind=expected_output_kind
         )
+        # Extract identity from the already-parsed doc (no re-read)
+        if parsed_doc and isinstance(parsed_doc, dict):
+            result["generated_api_version"] = parsed_doc.get("apiVersion") or ""
+            result["generated_kind"] = parsed_doc.get("kind") or ""
+            result["generated_name"] = (parsed_doc.get("metadata") or {}).get("name") or ""
+        else:
+            result["generated_api_version"] = ""
+            result["generated_kind"] = ""
+            result["generated_name"] = ""
+        # Classify stage based on which schema check failed
+        if schema_pass:
+            result["validation_stage"] = "passed"
+        elif any("Invalid YAML" in e for e in schema_errors):
+            result["validation_stage"] = "yaml_parse"
+        elif any("apiVersion" in e for e in schema_errors):
+            result["validation_stage"] = "schema_lookup"
+        else:
+            result["validation_stage"] = "schema_validation"
+
     result["schema_pass"] = schema_pass
     result["schema_errors"] = schema_errors
 
@@ -103,21 +128,16 @@ def evaluate(
     semantic_skipped = True
 
     if not skip_kyverno_test and kyverno_test_dir:
-        # Reuse Go validator output if available to avoid re-parsing YAML
+        # Reuse Go validator output or parsed doc to avoid re-reading YAML
         if go_result is not None:
             output_policy_name = go_result.get("policy_name")
             output_policy_kind = go_result.get("policy_kind", "")
+        elif parsed_doc and isinstance(parsed_doc, dict):
+            output_policy_name = (parsed_doc.get("metadata") or {}).get("name")
+            output_policy_kind = parsed_doc.get("kind", "")
         else:
-            output_doc: dict = {}
-            if yaml:
-                try:
-                    output_doc = yaml.safe_load(
-                        output_path.read_text(encoding="utf-8", errors="replace")
-                    ) or {}
-                except Exception:
-                    output_doc = {}
-            output_policy_name = (output_doc.get("metadata") or {}).get("name")
-            output_policy_kind = output_doc.get("kind", "")
+            output_policy_name = None
+            output_policy_kind = ""
         semantic_pass, semantic_errors, semantic_skipped = run_kyverno_test(
             kyverno_test_dir,
             output_policy_name=output_policy_name,

--- a/evaluators/schema_validator.py
+++ b/evaluators/schema_validator.py
@@ -24,25 +24,27 @@ def validate_schema(
     output_path: Path,
     *,
     expected_kind: str | None = None,
-) -> tuple[bool, list[str]]:
+) -> tuple[bool, list[str], dict | None]:
     """Validate the converted policy file against Kyverno 1.16+ schema.
 
-    Returns (passed, errors). This is the Python fallback — the Go validator
-    (cmd/validate-policy) is preferred and handles schema + CEL compilation.
+    Returns (passed, errors, parsed_doc). This is the Python fallback — the Go
+    validator (cmd/validate-policy) is preferred and handles schema + CEL
+    compilation.  The parsed doc is returned so callers can extract identity
+    fields without re-reading the file.
     """
     errors: list[str] = []
 
     if not yaml:
-        return False, ["PyYAML not installed. pip install pyyaml"]
+        return False, ["PyYAML not installed. pip install pyyaml"], None
 
     try:
         raw = output_path.read_text(encoding="utf-8", errors="replace")
         doc = yaml.safe_load(raw)
     except Exception as exc:
-        return False, [f"Invalid YAML: {exc}"]
+        return False, [f"Invalid YAML: {exc}"], None
 
     if not doc or not isinstance(doc, dict):
-        return False, ["Empty or non-dict YAML"]
+        return False, ["Empty or non-dict YAML"], None
 
     kind = doc.get("kind") or ""
     api_version = doc.get("apiVersion") or ""
@@ -62,4 +64,4 @@ def validate_schema(
             f"Expected apiVersion starting with {POLICIES_APIVERSION_PREFIX!r}, got {api_version!r}"
         )
 
-    return len(errors) == 0, errors
+    return len(errors) == 0, errors, doc

--- a/evaluators/semantic_validator.py
+++ b/evaluators/semantic_validator.py
@@ -137,6 +137,14 @@ def run_kyverno_test(
                 False,
             )
 
+    # Preflight: verify policy file exists before running test
+    if policy_under_test and not policy_under_test.exists():
+        return (
+            False,
+            [f"Policy file not found: {policy_under_test}"],
+            False,
+        )
+
     try:
         proc = subprocess.run(
             ["kyverno", "test", str(run_dir)],
@@ -164,8 +172,13 @@ def run_kyverno_test(
                 True,
             )
 
+        # Include policy path and test dir in error for diagnostics
+        preflight = f"[policy={policy_under_test}, test_dir={run_dir}]"
+        if "failed to load" in (out or "").lower() or "error loading" in (out or "").lower():
+            out = f"Policy load failed before test assertions. {preflight}\n{out}"
+
         if not out:
-            out = "kyverno test exited non-zero (no output)"
+            out = f"kyverno test exited non-zero (no output). {preflight}"
         return False, [out], False
     finally:
         if cleanup_dir and cleanup_dir.exists():

--- a/validate.py
+++ b/validate.py
@@ -134,7 +134,6 @@ def main() -> int:
         input_path,
         output_path,
         expected_output_kind=args.expected_kind,
-        use_kubectl=True,
         skip_kyverno_test=args.skip_kyverno_test,
         kyverno_test_dir=kyverno_test_dir if kyverno_test_dir.is_dir() else None,
         task_type=task_type,
@@ -169,6 +168,17 @@ def main() -> int:
     mode_label = "Generation" if is_generate else "Conversion"
     print(f"  {mode_label} validation results")
     print("  " + "-" * 40)
+
+    # Show generated policy identity
+    gen_api = eval_result.get("generated_api_version", "")
+    gen_kind = eval_result.get("generated_kind", "")
+    gen_name = eval_result.get("generated_name", "")
+    if gen_api or gen_kind or gen_name:
+        print(f"  Generated: apiVersion={gen_api}  kind={gen_kind}  name={gen_name}")
+    stage = eval_result.get("validation_stage", "")
+    if stage and stage != "passed":
+        print(f"  Failed at: {stage}")
+
     print(
         f"  1. Schema+CEL  {'PASS' if schema_pass else 'FAIL'}"
         f"  -- valid structure, CEL compiles"


### PR DESCRIPTION
## Summary

Closes #28

- **Generated policy identity** in run output and results JSON: `generated_api_version`, `generated_kind`, `generated_name`, plus file path and YAML preview (first 25 lines) on failure
- **Validation stage tagging**: Go validator classifies failures into `yaml_parse`, `schema_lookup`, `schema_validation`, `type_conversion`, `cel_compile`, `unknown_gvk`, or `passed` — surfaced as `validation_stage` in results
- **Semantic test preflight**: verifies policy file exists before running `kyverno test`, includes policy path and test dir in error messages on load failure
- **Benchmark log improvements**: failure lines now show GVK and stage inline (e.g., `FAIL  (got kyverno.io/v2beta1/ValidatingPolicy; stage=schema_lookup; ...)`)
- **Eliminated redundant file reads**: `validate_schema()` now returns parsed doc; `evaluate.py` reuses it for identity extraction and semantic test setup (3 YAML reads → 1)
- **Bugfix**: removed stale `use_kubectl=True` kwarg passed to `evaluate()` from `validate.py`

### Example output (bad apiVersion)

```
  Generation validation results
  ----------------------------------------
  Generated: apiVersion=kyverno.io/v2beta1  kind=ValidatingPolicy  name=test-bad-api
  Failed at: schema_lookup
  1. Schema+CEL  FAIL  -- valid structure, CEL compiles
      - schema validation failed: failed to parse document (failed to retrieve validator: ...)
```

### Example results JSON (new fields)

```json
{
  "generated_api_version": "kyverno.io/v2beta1",
  "generated_kind": "ValidatingPolicy",
  "generated_name": "test-bad-api",
  "validation_stage": "schema_lookup",
  "yaml_preview": "apiVersion: kyverno.io/v2beta1\nkind: ValidatingPolicy\n..."
}
```

## Test plan

- [x] Smoke-tested with a policy using wrong `apiVersion` (`kyverno.io/v2beta1`) — all new fields appear in output and JSON
- [x] Go validator compiles (`GOWORK=off go build`)
- [x] All Python modules import cleanly
- [ ] Run full benchmark suite (`./run-benchmark.sh --tool nctl`) to verify no regressions