### PR TITLE
fix: reverse X-axis on Accuracy vs Cost scatter chart

### DIFF
--- a/reports/templates/dashboard.html.j2
+++ b/reports/templates/dashboard.html.j2
@@ -185,7 +185,7 @@ new Chart(document.getElementById('scatterChart'), {
       tooltip: { callbacks: { label: ctx => ctx.dataset.label + ': ' + ctx.raw.y.toFixed(0) + '% pass, $' + (ctx.raw.x / 1000).toFixed(4) + '/task' } }
     },
     scales: {
-      x: { ...scaleOpts, title: { display: true, text: 'Avg Cost per Task ($ x1000)', color: tickColor }, grid: { color: gridColor } },
+      x: { ...scaleOpts, reverse: true, title: { display: true, text: 'Avg Cost per Task ($ ×1000) — lower is better →', color: tickColor }, grid: { color: gridColor } },
       y: { ...scaleOpts, title: { display: true, text: 'Pass Rate (%)', color: tickColor }, beginAtZero: true, max: 100, ticks: { ...scaleOpts.ticks, callback: v => v + '%' } }
     }
   }


### PR DESCRIPTION
## Summary
- Reverses the X-axis on the "Accuracy vs Cost" scatter chart so lower cost appears on the right
- Top-right quadrant now represents the ideal: highest accuracy + lowest cost
- Adds directional axis label ("lower is better →") for clarity

Closes #35

## Test plan
- [ ] Run `reports/generate.py` and open the output dashboard
- [ ] Verify the scatter chart X-axis runs from high cost (left) to low cost (right)
- [ ] Verify tooltips still show correct dollar values
- [ ] Confirm top-right = best-performing tool