### PR TITLE
fix(validate): remove invalid use_kubectl kwarg passed to evaluate()

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -134,7 +134,6 @@ def main() -> int:
         input_path,
         output_path,
         expected_output_kind=args.expected_kind,
-        use_kubectl=True,
         skip_kyverno_test=args.skip_kyverno_test,
         kyverno_test_dir=kyverno_test_dir if kyverno_test_dir.is_dir() else None,
         task_type=task_type,


### PR DESCRIPTION
## Summary
Removes `use_kubectl=True` from the `evaluate(...)` call in `validate.py`. `evaluators.evaluate.evaluate()` does not accept that parameter, which caused:

```
TypeError: evaluate() got an unexpected keyword argument 'use_kubectl'
```

when running conversion validation (`--input` + `--output`).

`validate_input(...)` still uses `use_kubectl` where supported.

## Testing
- `python3 validate.py --input input/require-resource-limits.yaml --output <converted.yaml> --tool manual` completes without TypeError

Fixes #40

Made with [Cursor](https://cursor.com)