### PR TITLE
feat(validate): promote expected-kind to a distinct fail-fast step

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -207,13 +207,17 @@ def _run_single(
             prompt = base_prompt
 
         # Augment prompt on retry with previous errors (only latest attempt)
-        if attempt > 1 and last_result.get("schema_errors"):
-            prev_errs = last_result.get("schema_errors", [])
-            prompt += (
-                "\n\nThe previous attempt had these errors:\n"
-                + "\n".join(f"- {e}" for e in prev_errs)
-                + "\nPlease fix them."
+        if attempt > 1:
+            prev_errs = (
+                last_result.get("expected_kind_errors", [])
+                + last_result.get("schema_errors", [])
             )
+            if prev_errs:
+                prompt += (
+                    "\n\nThe previous attempt had these errors:\n"
+                    + "\n".join(f"- {e}" for e in prev_errs)
+                    + "\nPlease fix them."
+                )
 
         run_result: RunResult = runner.run(
             input_path or output_path,
@@ -309,7 +313,11 @@ def _failure_detail(result: dict) -> str:
     stage = result.get("validation_stage")
     if stage and stage != "passed":
         parts.append(f"stage={stage}")
-    errs = result.get("schema_errors") or result.get("error")
+    errs = (
+        result.get("expected_kind_errors")
+        or result.get("schema_errors")
+        or result.get("error")
+    )
     if isinstance(errs, list) and errs:
         parts.append(errs[0][:80])
     elif isinstance(errs, str):

--- a/evaluators/evaluate.py
+++ b/evaluators/evaluate.py
@@ -74,7 +74,10 @@ def evaluate(
     kind_errors: list[str] = []
     kind_skipped = expected_output_kind is None
 
-    if expected_output_kind and yaml:
+    if expected_output_kind and yaml is None:
+        kind_pass = False
+        kind_errors.append("PyYAML not installed; cannot check expected kind")
+    elif expected_output_kind:
         try:
             raw = output_path.read_text(encoding="utf-8", errors="replace")
             doc = yaml.safe_load(raw)

--- a/evaluators/evaluate.py
+++ b/evaluators/evaluate.py
@@ -57,15 +57,67 @@ def evaluate(
 ) -> dict:
     """Run evaluation and return a results dict.
 
-    Three layers:
-      1. Schema + CEL (Go validator preferred, Python fallback)
-      2. Structural lint (catches common MutatingPolicy issues)
-      3. Functional test (kyverno test with real resources)
+    Four layers (in order):
+      1. Expected kind (cheap fail-fast — skipped when not specified)
+      2. Schema + CEL (Go validator preferred, Python fallback)
+      3. Structural lint (catches common MutatingPolicy issues)
+      4. Functional test (kyverno test with real resources)
 
-    Keys: schema_pass, schema_errors, lint_pass, lint_warnings,
+    Keys: expected_kind_pass, expected_kind_errors, expected_kind_skipped,
+          schema_pass, schema_errors, lint_pass, lint_warnings,
           semantic_pass, semantic_errors, semantic_skipped, validator_used.
     """
     result: dict = {}
+
+    # --- Expected kind (cheapest possible fail-fast check) ---
+    kind_pass = True
+    kind_errors: list[str] = []
+    kind_skipped = expected_output_kind is None
+
+    if expected_output_kind and yaml:
+        try:
+            raw = output_path.read_text(encoding="utf-8", errors="replace")
+            doc = yaml.safe_load(raw)
+            if isinstance(doc, dict):
+                actual_kind = doc.get("kind", "")
+                allowed = {expected_output_kind}
+                if expected_output_kind == "DeletingPolicy":
+                    allowed.add("NamespacedDeletingPolicy")
+                if actual_kind not in allowed:
+                    kind_pass = False
+                    kind_errors.append(
+                        f"Expected kind {sorted(allowed)}, got {actual_kind!r}"
+                    )
+                    # Populate identity for diagnostics on the early-return path;
+                    # on the happy path the downstream validator sets these.
+                    result["generated_api_version"] = doc.get("apiVersion") or ""
+                    result["generated_kind"] = actual_kind
+                    result["generated_name"] = (doc.get("metadata") or {}).get("name") or ""
+            else:
+                kind_pass = False
+                kind_errors.append("Output is not a YAML mapping")
+        except Exception as exc:
+            kind_pass = False
+            kind_errors.append(f"Failed to parse YAML for kind check: {exc}")
+
+    result["expected_kind_pass"] = kind_pass
+    result["expected_kind_errors"] = kind_errors
+    result["expected_kind_skipped"] = kind_skipped
+
+    if not kind_pass:
+        result["validation_stage"] = "expected_kind"
+        result.setdefault("generated_api_version", "")
+        result.setdefault("generated_kind", "")
+        result.setdefault("generated_name", "")
+        result["schema_pass"] = False
+        result["schema_errors"] = []
+        result["validator_used"] = "skipped"
+        result["lint_pass"] = None
+        result["lint_warnings"] = []
+        result["semantic_pass"] = None
+        result["semantic_errors"] = []
+        result["semantic_skipped"] = True
+        return result
 
     # --- Schema + CEL (Go validator preferred, Python fallback) ---
     go_result = validate_with_go(output_path)
@@ -79,22 +131,9 @@ def evaluate(
         result["generated_kind"] = go_result.get("policy_kind", "")
         result["generated_name"] = go_result.get("policy_name", "")
         result["validation_stage"] = go_result.get("validation_stage", "")
-
-        if schema_pass and expected_output_kind:
-            actual_kind = go_result.get("policy_kind", "")
-            allowed = {expected_output_kind}
-            if expected_output_kind == "DeletingPolicy":
-                allowed.add("NamespacedDeletingPolicy")
-            if actual_kind not in allowed:
-                schema_pass = False
-                schema_errors.append(
-                    f"Expected kind {sorted(allowed)}, got {actual_kind!r}"
-                )
     else:
         result["validator_used"] = "python_fallback"
-        schema_pass, schema_errors, parsed_doc = validate_schema(
-            output_path, expected_kind=expected_output_kind
-        )
+        schema_pass, schema_errors, parsed_doc = validate_schema(output_path)
         # Extract identity from the already-parsed doc (no re-read)
         if parsed_doc and isinstance(parsed_doc, dict):
             result["generated_api_version"] = parsed_doc.get("apiVersion") or ""

--- a/evaluators/schema_validator.py
+++ b/evaluators/schema_validator.py
@@ -22,8 +22,6 @@ POLICIES_APIVERSION_PREFIX = "policies.kyverno.io/"
 
 def validate_schema(
     output_path: Path,
-    *,
-    expected_kind: str | None = None,
 ) -> tuple[bool, list[str], dict | None]:
     """Validate the converted policy file against Kyverno 1.16+ schema.
 
@@ -31,6 +29,10 @@ def validate_schema(
     validator (cmd/validate-policy) is preferred and handles schema + CEL
     compilation.  The parsed doc is returned so callers can extract identity
     fields without re-reading the file.
+
+    Note: expected-kind checking is handled earlier in evaluate() as a
+    separate fail-fast step, so this only validates against the full set
+    of known policy kinds.
     """
     errors: list[str] = []
 
@@ -49,15 +51,9 @@ def validate_schema(
     kind = doc.get("kind") or ""
     api_version = doc.get("apiVersion") or ""
 
-    allowed_kinds = VALIDATING_POLICY_KINDS
-    if expected_kind:
-        allowed_kinds = {expected_kind}
-        if expected_kind == "DeletingPolicy":
-            allowed_kinds.add("NamespacedDeletingPolicy")
-
-    if kind not in allowed_kinds:
+    if kind not in VALIDATING_POLICY_KINDS:
         errors.append(
-            f"Expected kind in {sorted(allowed_kinds)}, got {kind!r}"
+            f"Expected kind in {sorted(VALIDATING_POLICY_KINDS)}, got {kind!r}"
         )
     if not api_version.startswith(POLICIES_APIVERSION_PREFIX):
         errors.append(

--- a/validate.py
+++ b/validate.py
@@ -4,8 +4,8 @@ Validate a converted or generated policy.
 
 Three modes:
   1. **Input-only** — validate a source policy before converting.
-  2. **Conversion** (input + output) — schema + CEL + functional test.
-  3. **Generation / output-only** (output only, no input) — schema + CEL.
+  2. **Conversion** (input + output) — expected kind + schema + CEL + functional test.
+  3. **Generation / output-only** (output only, no input) — expected kind + schema + CEL.
 
 Usage:
   # Validate input policy only:
@@ -158,6 +158,9 @@ def main() -> int:
     out_json.write_text(json.dumps(report, indent=2), encoding="utf-8")
 
     # --- Pretty summary ---
+    kind_pass = eval_result.get("expected_kind_pass", True)
+    kind_skipped = eval_result.get("expected_kind_skipped", True)
+    kind_errors = eval_result.get("expected_kind_errors", [])
     schema_pass = eval_result["schema_pass"]
     semantic_pass = eval_result.get("semantic_pass")
     semantic_skipped = eval_result.get("semantic_skipped", True)
@@ -179,19 +182,38 @@ def main() -> int:
     if stage and stage != "passed":
         print(f"  Failed at: {stage}")
 
-    print(
-        f"  1. Schema+CEL  {'PASS' if schema_pass else 'FAIL'}"
-        f"  -- valid structure, CEL compiles"
-    )
-    for e in schema_errors:
-        print(f"      - {e}")
+    step = 0
 
-    if semantic_skipped:
-        reason = semantic_errors[0] if semantic_errors else "no test dir or kyverno CLI not on PATH"
-        print(f"  2. Functional  SKIP  -- {reason}")
+    # Expected kind (only shown when --expected-kind was provided)
+    if not kind_skipped:
+        step += 1
+        print(
+            f"  {step}. Expected Kind  {'PASS' if kind_pass else 'FAIL'}"
+            f"  -- output kind matches {args.expected_kind}"
+        )
+        for e in kind_errors:
+            print(f"      - {e}")
+
+    schema_skipped = not kind_pass
+
+    step += 1
+    if schema_skipped:
+        print(f"  {step}. Schema+CEL     SKIP  -- expected kind failed")
     else:
         print(
-            f"  2. Functional  {'PASS' if semantic_pass else 'FAIL'}"
+            f"  {step}. Schema+CEL     {'PASS' if schema_pass else 'FAIL'}"
+            f"  -- valid structure, CEL compiles"
+        )
+        for e in schema_errors:
+            print(f"      - {e}")
+
+    step += 1
+    if semantic_skipped:
+        reason = semantic_errors[0] if semantic_errors else "no test dir or kyverno CLI not on PATH"
+        print(f"  {step}. Functional     SKIP  -- {reason}")
+    else:
+        print(
+            f"  {step}. Functional     {'PASS' if semantic_pass else 'FAIL'}"
             f"  -- kyverno test (policy behavior)"
         )
         for e in semantic_errors:
@@ -203,7 +225,7 @@ def main() -> int:
     print(f"  Results: {out_json}")
     print()
 
-    all_pass = schema_pass and (semantic_skipped or semantic_pass)
+    all_pass = kind_pass and schema_pass and (semantic_skipped or semantic_pass)
     return 0 if all_pass else 1
 
 


### PR DESCRIPTION
## Summary
- Extract the `--expected-kind` check out of Schema+CEL and run it first as its own layer. Short-circuits expensive CEL compilation and Kyverno CLI tests when the output policy is fundamentally the wrong kind.
- Render the expected-kind check as a distinct step in the CLI output (only shown when `--expected-kind` is provided). When it fails, Schema+CEL and Functional show SKIP so the actual failure is unambiguous.
- Drop the `expected_kind` parameter from `validate_schema()`; it's handled upstream now.

## Why
Two issues with the previous behavior:
1. The expected-kind check was buried inside the schema step, so a wrong-kind failure was reported as "Schema+CEL FAIL" even though schema/CEL were never actually tested — misleading diagnostics.
2. Ordering: expected-kind is the cheapest possible validation (a single YAML parse + string comparison). Running it before Schema+CEL and the functional test follows the fail-fast principle — no point compiling CEL or invoking \`kyverno test\` on output that is fundamentally the wrong kind.

Note: Schema+CEL is still kept because its unique value is compiling **all** CEL expressions upfront (the Kyverno CLI test only exercises CEL paths hit by test resources).

## Output examples

Without `--expected-kind` (unchanged behavior):
\`\`\`
  1. Schema+CEL     PASS  -- valid structure, CEL compiles
  2. Functional     PASS  -- kyverno test (policy behavior)
\`\`\`

With `--expected-kind ValidatingPolicy` matching:
\`\`\`
  1. Expected Kind  PASS  -- output kind matches ValidatingPolicy
  2. Schema+CEL     PASS  -- valid structure, CEL compiles
  3. Functional     PASS  -- kyverno test (policy behavior)
\`\`\`

With `--expected-kind MutatingPolicy` mismatching (short-circuits):
\`\`\`
  Failed at: expected_kind
  1. Expected Kind  FAIL  -- output kind matches MutatingPolicy
      - Expected kind ['MutatingPolicy'], got 'ValidatingPolicy'
  2. Schema+CEL     SKIP  -- expected kind failed
  3. Functional     SKIP  -- no test dir or kyverno CLI not on PATH
\`\`\`

Closes #42

## Test plan
- [x] Verified `python3 validate.py --output <vpol>.yaml --skip-kyverno-test` (no expected-kind) still shows 2 steps
- [x] Verified `--expected-kind ValidatingPolicy` matching shows 3 steps, all PASS
- [x] Verified `--expected-kind MutatingPolicy` mismatching short-circuits (exit 1), Schema+CEL and Functional show SKIP
- [x] Verified identity fields (`Generated: apiVersion=... kind=... name=...`) populate on both pass and failure paths
- [x] Verified `benchmark.py` still passes `expected_output_kind=` to `evaluate()` (signature unchanged)