### PR TITLE
feat(dataset): generation tasks with upstream functional verification

### DIFF
--- a/dataset/imported/upstream-meta.json
+++ b/dataset/imported/upstream-meta.json
@@ -2,6 +2,6 @@
   "repository": "https://github.com/kyverno/policies.git",
   "ref": "75a68932d86a67eea055089ec18311284877d296",
   "upstream_root": "policies-75a68932d86a67eea055089ec18311284877d296",
-  "policy_count": 32,
-  "tests_synced": 32
+  "policy_count": 35,
+  "tests_synced": 35
 }

--- a/dataset/index.yaml
+++ b/dataset/index.yaml
@@ -273,3 +273,69 @@ policies:
   kyverno_test_dir: imported/kyverno-tests/cp_kasten_generate_by_label
   description: generates a Kasten policy for a new namespace that includes a valid "dataprotection" label, if the policy does
     not already exist
+- id: gen_require_labels
+  track: cluster-policy
+  task_type: generate
+  difficulty: easy
+  expected_output_kind: ValidatingPolicy
+  description: requires all Pods to have the label 'app.kubernetes.io/name' set to a non-empty value. Deny admission if the
+    label is missing or empty.
+- id: gen_disallow_privileged
+  track: cluster-policy
+  task_type: generate
+  difficulty: easy
+  expected_output_kind: ValidatingPolicy
+  description: denies any Pod with securityContext.privileged set to true on any container.
+- id: gen_restrict_registries
+  track: cluster-policy
+  task_type: generate
+  difficulty: easy
+  expected_output_kind: ValidatingPolicy
+  description: only allows container images from 'gcr.io/' and 'docker.io/library/' registries. Deny any image from other
+    registries.
+- id: gen_require_resource_limits
+  track: cluster-policy
+  task_type: generate
+  difficulty: medium
+  expected_output_kind: ValidatingPolicy
+  description: requires CPU and memory limits on all containers, including initContainers, in Pods. Deny admission if any
+    container is missing limits.
+- id: gen_disallow_host_namespaces
+  track: cluster-policy
+  task_type: generate
+  difficulty: medium
+  expected_output_kind: ValidatingPolicy
+  description: denies Pods that use hostNetwork, hostPID, or hostIPC. All three must be checked.
+- id: gen_restrict_volume_types
+  track: cluster-policy
+  task_type: generate
+  difficulty: hard
+  expected_output_kind: ValidatingPolicy
+  description: 'only allows these volume types: emptyDir, configMap, secret, projected, downwardAPI, and persistentVolumeClaim.
+    Deny any Pod with other volume types like hostPath.'
+- id: gen_pod_security_baseline
+  track: cluster-policy
+  task_type: generate
+  difficulty: hard
+  expected_output_kind: ValidatingPolicy
+  description: 'implements multiple Pod Security Standards baseline checks in a single policy: disallow privileged containers,
+    disallow hostPID/hostIPC/hostNetwork, require non-root containers, and drop ALL capabilities.'
+- id: gen_add_default_labels
+  track: cluster-policy
+  task_type: generate
+  difficulty: easy
+  expected_output_kind: MutatingPolicy
+  description: 'adds the label ''managed-by: kyverno'' to all new Deployments that do not already have it.'
+- id: gen_inject_sidecar
+  track: cluster-policy
+  task_type: generate
+  difficulty: medium
+  expected_output_kind: MutatingPolicy
+  description: 'injects an Envoy sidecar container (image: envoyproxy/envoy:v1.28, port 9901) into any Pod that has the annotation
+    ''inject-sidecar: true''.'
+- id: gen_create_networkpolicy
+  track: cluster-policy
+  task_type: generate
+  difficulty: medium
+  expected_output_kind: GeneratingPolicy
+  description: generates a default-deny NetworkPolicy (deny all ingress and egress) whenever a new Namespace is created.

--- a/dataset/index.yaml
+++ b/dataset/index.yaml
@@ -278,6 +278,7 @@ policies:
   task_type: generate
   difficulty: easy
   expected_output_kind: ValidatingPolicy
+  kyverno_test_dir: imported/kyverno-tests/cp_require_labels
   description: requires all Pods to have the label 'app.kubernetes.io/name' set to a non-empty value. Deny admission if the
     label is missing or empty.
 - id: gen_disallow_privileged
@@ -285,57 +286,65 @@ policies:
   task_type: generate
   difficulty: easy
   expected_output_kind: ValidatingPolicy
-  description: denies any Pod with securityContext.privileged set to true on any container.
+  kyverno_test_dir: imported/kyverno-tests/cp_disallow_privileged
+  description: denies any Pod, Deployment, or CronJob whose containers, initContainers, or ephemeralContainers set securityContext.privileged
+    to true.
 - id: gen_restrict_registries
   track: cluster-policy
   task_type: generate
   difficulty: easy
   expected_output_kind: ValidatingPolicy
-  description: only allows container images from 'gcr.io/' and 'docker.io/library/' registries. Deny any image from other
-    registries.
+  kyverno_test_dir: imported/kyverno-tests/cp_restrict_image_registries
+  description: only allows Pod container images that begin with the prefix 'eu.foo.io/' or 'bar.io/'. Deny any Pod whose containers
+    use images from any other registry.
 - id: gen_require_resource_limits
   track: cluster-policy
   task_type: generate
   difficulty: medium
   expected_output_kind: ValidatingPolicy
-  description: requires CPU and memory limits on all containers, including initContainers, in Pods. Deny admission if any
-    container is missing limits.
+  kyverno_test_dir: imported/kyverno-tests/cp_require_resource_limits
+  description: requires every container in a Pod to set spec.containers[].resources.requests.memory, spec.containers[].resources.requests.cpu,
+    and spec.containers[].resources.limits.memory. Deny admission if any container is missing any of these three fields. CPU
+    limit is NOT required.
 - id: gen_disallow_host_namespaces
   track: cluster-policy
   task_type: generate
   difficulty: medium
   expected_output_kind: ValidatingPolicy
-  description: denies Pods that use hostNetwork, hostPID, or hostIPC. All three must be checked.
-- id: gen_restrict_volume_types
+  kyverno_test_dir: imported/kyverno-tests/cp_disallow_host_namespaces
+  description: denies Pods, Deployments, and CronJobs that set spec.hostNetwork, spec.hostPID, or spec.hostIPC to true. All
+    three host namespace fields must be checked.
+- id: gen_disallow_host_path
   track: cluster-policy
   task_type: generate
   difficulty: hard
   expected_output_kind: ValidatingPolicy
-  description: 'only allows these volume types: emptyDir, configMap, secret, projected, downwardAPI, and persistentVolumeClaim.
-    Deny any Pod with other volume types like hostPath.'
-- id: gen_pod_security_baseline
+  kyverno_test_dir: imported/kyverno-tests/gen_disallow_host_path
+  description: denies Pods, Deployments, and CronJobs that use any hostPath volume. The check must reject any volume in spec.volumes
+    whose hostPath field is set, regardless of the hostPath value.
+- id: gen_disallow_capabilities
   track: cluster-policy
   task_type: generate
   difficulty: hard
   expected_output_kind: ValidatingPolicy
-  description: 'implements multiple Pod Security Standards baseline checks in a single policy: disallow privileged containers,
-    disallow hostPID/hostIPC/hostNetwork, require non-root containers, and drop ALL capabilities.'
+  kyverno_test_dir: imported/kyverno-tests/gen_disallow_capabilities
+  description: denies Pods, Deployments, and CronJobs whose containers, initContainers, or ephemeralContainers add any Linux
+    capability via securityContext.capabilities.add beyond the Pod Security Standards baseline allow-list (AUDIT_WRITE, CHOWN,
+    DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT).
 - id: gen_add_default_labels
   track: cluster-policy
   task_type: generate
   difficulty: easy
   expected_output_kind: MutatingPolicy
-  description: 'adds the label ''managed-by: kyverno'' to all new Deployments that do not already have it.'
-- id: gen_inject_sidecar
-  track: cluster-policy
-  task_type: generate
-  difficulty: medium
-  expected_output_kind: MutatingPolicy
-  description: 'injects an Envoy sidecar container (image: envoyproxy/envoy:v1.28, port 9901) into any Pod that has the annotation
-    ''inject-sidecar: true''.'
+  kyverno_test_dir: imported/kyverno-tests/cp_add_default_labels
+  description: 'mutates Pods and Services to add the label ''foo: bar'' to metadata.labels. The label must be added if absent
+    and left unchanged if already present.'
 - id: gen_create_networkpolicy
   track: cluster-policy
   task_type: generate
   difficulty: medium
   expected_output_kind: GeneratingPolicy
-  description: generates a default-deny NetworkPolicy (deny all ingress and egress) whenever a new Namespace is created.
+  kyverno_test_dir: imported/kyverno-tests/gen_create_networkpolicy
+  description: generates a NetworkPolicy named 'default-deny' in any newly-created Namespace. The generated NetworkPolicy
+    must select all Pods (empty podSelector), include both 'Ingress' and 'Egress' policyTypes, and define no ingress or egress
+    rules so all traffic is denied by default.

--- a/dataset/kyverno-upstream-manifest.yaml
+++ b/dataset/kyverno-upstream-manifest.yaml
@@ -162,3 +162,23 @@ policies:
   - id: cp_kasten_generate_by_label
     upstream_path: kasten/kasten-generate-policy-by-preset-label/kasten-generate-policy-by-preset-label.yaml
     sync_test: true
+
+  # =====================================================================
+  # Generation tasks — upstream tests reused as functional verification
+  # for natural-language → policy generation. The dataset entries with
+  # task_type=generate point at these test directories so the LLM is
+  # asked to author a policy whose behavior matches what the upstream
+  # test fixtures verify.
+  # =====================================================================
+
+  - id: gen_create_networkpolicy
+    upstream_path: best-practices-gpol/add-network-policy/add-network-policy.yaml
+    sync_test: true
+
+  - id: gen_disallow_host_path
+    upstream_path: pod-security/baseline/disallow-host-path/disallow-host-path.yaml
+    sync_test: true
+
+  - id: gen_disallow_capabilities
+    upstream_path: pod-security/baseline/disallow-capabilities/disallow-capabilities.yaml
+    sync_test: true


### PR DESCRIPTION
## Summary

Two-commit branch that brings the benchmark's generation half up to the same functional-verification bar as the conversion half.

**Commit 1** restores the 10 `task_type: generate` entries that were removed in commit `1e94625` (April 2). The infrastructure for them was never removed (`runners/prompts.py:72` `_GENERATION_PROMPT`, `benchmark.py:141` `is_generate`, `evaluators/evaluate.py` already supports `input_path=None`), so this is a data-only restoration.

**Commit 2** pairs every generation task with an upstream Kyverno CLI test directory so the generated policies are functionally verified, not just schema-validated. Three sub-changes:

1. **Five existing tests reused** with no modification — `gen_require_labels`, `gen_disallow_privileged`, `gen_disallow_host_namespaces`, plus the two replacements below — point at already-imported `cp_*` test directories whose pass/fail fixtures align with the gen description.
2. **Three descriptions tightened** so the LLM-generated policy matches what the upstream test fixtures actually verify:
   - `gen_restrict_registries`: upstream test allows `eu.foo.io/` and `bar.io/`, not `gcr.io/` and `docker.io/library/`
   - `gen_require_resource_limits`: upstream policy requires memory limit + memory request + cpu request, NOT cpu limit
   - `gen_add_default_labels`: upstream test patches add the literal label `foo: bar`, not `managed-by: kyverno`
3. **Three task substitutions** to keep all tasks functionally testable:
   - **`gen_inject_sidecar` DROPPED.** The upstream `cp_inject_sidecar` test does an exact-match comparison against a Vault sidecar `patchedResource.yaml`. Mutation tests are too brittle for a generation benchmark — even small LLM variance in field ordering fails the byte-match.
   - **`gen_restrict_volume_types` REPLACED with `gen_disallow_host_path`** — no upstream "restrict volume types" single policy exists; `pod-security/baseline/disallow-host-path` is the closest baseline check with a paired test.
   - **`gen_pod_security_baseline` REPLACED with `gen_disallow_capabilities`** — PSS baseline is split into 11 individual checks upstream; `disallow-capabilities` is the broadest single check with a paired test.

**Three new manifest entries** added to `dataset/kyverno-upstream-manifest.yaml` for the newly-paired tests, all from existing upstream paths verified to exist at the manifest's pinned ref `75a68932d86a67eea055089ec18311284877d296`. `dataset/imported/upstream-meta.json` regenerated to reflect the new policy count of 35 (32 `cp_` + 3 `gen_`).

Related to #44.

## Final dataset shape

| Metric | Before this PR | After this PR |
|---|---|---|
| Total tasks | 32 | **41** |
| Convert tasks | 32 | 32 (unchanged) |
| Generation tasks | 0 | **9** |
| Tasks with paired functional tests | 32/32 | **41/41** |

## Generation tasks (9)

| ID | Kind | Difficulty | Paired test |
|---|---|---|---|
| `gen_require_labels` | ValidatingPolicy | easy | `imported/kyverno-tests/cp_require_labels` |
| `gen_disallow_privileged` | ValidatingPolicy | easy | `imported/kyverno-tests/cp_disallow_privileged` |
| `gen_restrict_registries` | ValidatingPolicy | easy | `imported/kyverno-tests/cp_restrict_image_registries` |
| `gen_require_resource_limits` | ValidatingPolicy | medium | `imported/kyverno-tests/cp_require_resource_limits` |
| `gen_disallow_host_namespaces` | ValidatingPolicy | medium | `imported/kyverno-tests/cp_disallow_host_namespaces` |
| `gen_disallow_host_path` | ValidatingPolicy | hard | `imported/kyverno-tests/gen_disallow_host_path` (new) |
| `gen_disallow_capabilities` | ValidatingPolicy | hard | `imported/kyverno-tests/gen_disallow_capabilities` (new) |
| `gen_add_default_labels` | MutatingPolicy | easy | `imported/kyverno-tests/cp_add_default_labels` |
| `gen_create_networkpolicy` | GeneratingPolicy | medium | `imported/kyverno-tests/gen_create_networkpolicy` (new) |

## Relationship to PR #45

Independent — can merge in either order. After #45 lands, the `_GENERATION_PROMPT` template gains the `(apiVersion: policies.kyverno.io/v1)` nudge and these generation tasks benefit from it automatically.

## Test plan

- [x] `python3 -c "import yaml; d=yaml.safe_load(open('dataset/index.yaml')); print(len(d['policies']))"` returns `41`
- [x] All 9 generation tasks have a `kyverno_test_dir` field; every referenced directory exists on disk after `python3 scripts/sync_kyverno_policies.py`
- [x] `python3 scripts/sync_kyverno_policies.py` succeeds at the pinned ref and downloads all 35 policies + tests (32 `cp_` + 3 `gen_`)
- [x] `gen_inject_sidecar` no longer present in the dataset
- [x] `gen_restrict_volume_types` and `gen_pod_security_baseline` replaced with `gen_disallow_host_path` and `gen_disallow_capabilities`
- [ ] Reviewer spot-check: the 3 new manifest entries point at upstream paths that exist at the pinned ref
- [ ] Full benchmark run on the updated dataset to confirm functional tests actually fire on the generation tasks (separate task — happening locally as part of the same investigation)
- [ ] CI passes