### PR TITLE
build: pin nctl to a tagged release and auto-download via gh CLI

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,24 +1,86 @@
 #!/bin/bash
 # Build all benchmark container images.
 #
+# For the public benchmark, the nctl binary is fetched from the pinned
+# GitHub release (see NCTL_VERSION below). Bumping this pin is how the
+# benchmark adopts new upstream nctl work — do it as a small PR so the
+# reproducibility history stays traceable.
+#
 # Usage:
-#   ./build.sh                           # build all (nctl binary must be at ./nctl)
-#   ./build.sh --nctl-bin /path/to/nctl  # specify nctl binary path
-#   ./build.sh --only nctl               # build base + one tool only
+#   ./build.sh                              # download pinned nctl release, build all
+#   ./build.sh --only nctl                  # download pinned nctl release, build nctl only
+#   ./build.sh --nctl-version v4.10.15      # override pinned release (for a bump PR)
+#   ./build.sh --nctl-bin /path/to/nctl     # use a locally-built binary (internal dev only;
+#                                           # bypasses the release download so you can test
+#                                           # unmerged branches. NOT for public repro runs.)
 set -e
 
 cd "$(dirname "$0")"
 
-NCTL_BIN="nctl"
+# Pinned nctl release for reproducible benchmarks. Bump via PR.
+# See https://github.com/nirmata/go-nctl/releases for available versions.
+NCTL_VERSION="${NCTL_VERSION:-v4.10.14}"
+NCTL_BIN=""
 ONLY=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --nctl-bin) NCTL_BIN="$2"; shift 2 ;;
-    --only)     ONLY="$2"; shift 2 ;;
-    *)          echo "Unknown arg: $1" >&2; exit 1 ;;
+    --nctl-bin)     NCTL_BIN="$2"; shift 2 ;;
+    --nctl-version) NCTL_VERSION="$2"; shift 2 ;;
+    --only)         ONLY="$2"; shift 2 ;;
+    *)              echo "Unknown arg: $1" >&2; exit 1 ;;
   esac
 done
+
+# Resolve which nctl binary to bake into the image.
+# Precedence:
+#   1. --nctl-bin <path>  (internal dev: local build from any branch/SHA)
+#   2. Pre-existing ./nctl next to this script (manual override)
+#   3. Download pinned release NCTL_VERSION from GitHub Releases (public path)
+if [[ -n "$NCTL_BIN" ]]; then
+  if [[ ! -f "$NCTL_BIN" ]]; then
+    echo "ERROR: --nctl-bin path does not exist: $NCTL_BIN" >&2
+    exit 1
+  fi
+  # Dockerfile.nctl uses NCTL_BIN as a path relative to this build context,
+  # so normalize by copying into ./nctl.
+  if [[ "$(cd "$(dirname "$NCTL_BIN")" && pwd)/$(basename "$NCTL_BIN")" != "$(pwd)/nctl" ]]; then
+    cp "$NCTL_BIN" ./nctl
+  fi
+  echo "==> Using locally-supplied nctl binary (--nctl-bin) — internal dev mode"
+  echo "    Public reproducibility requires the pinned release; use --nctl-version or no flag for that."
+  NCTL_BIN="nctl"
+elif [[ -f ./nctl ]]; then
+  echo "==> Using existing ./nctl (delete it to force re-download of ${NCTL_VERSION})"
+  NCTL_BIN="nctl"
+else
+  case "$(uname -m)" in
+    arm64|aarch64) ARCH=arm64 ;;
+    x86_64|amd64)  ARCH=amd64 ;;
+    *) echo "ERROR: unsupported host arch $(uname -m)" >&2; exit 1 ;;
+  esac
+  V="${NCTL_VERSION#v}"
+  ASSET="nctl_${V}_linux_${ARCH}.zip"
+  echo "==> Downloading nctl ${NCTL_VERSION} (${ASSET}) via gh CLI"
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: 'gh' CLI not found on PATH. The nctl release assets live in a" >&2
+    echo "private GitHub repo (nirmata/go-nctl), so 'gh auth login' is required" >&2
+    echo "to fetch them. Install: https://cli.github.com/  OR pass --nctl-bin" >&2
+    echo "to use a locally-built binary." >&2
+    exit 1
+  fi
+  TMPDIR_LOCAL="$(mktemp -d -t nctl-release-XXXXXX)"
+  trap 'rm -rf "${TMPDIR_LOCAL}"' EXIT
+  gh release download "${NCTL_VERSION}" \
+    --repo nirmata/go-nctl \
+    --pattern "${ASSET}" \
+    --dir "${TMPDIR_LOCAL}" \
+    --clobber
+  unzip -o -j "${TMPDIR_LOCAL}/${ASSET}" nctl -d .
+  chmod +x ./nctl
+  echo "    saved to $(pwd)/nctl"
+  NCTL_BIN="nctl"
+fi
 
 echo "==> Building benchmark-base..."
 docker build -f Dockerfile.base -t benchmark-base .


### PR DESCRIPTION
## Summary

Makes the public benchmark reproducible against a specific tagged `nctl` release instead of requiring callers to supply their own locally-built binary. The pinned version lives at the top of `docker/build.sh` and is bumped via PR as new releases ship — this keeps the benchmark history traceable ("run at policy-bench SHA X, nctl vY.Z gave these numbers").

## What changed

Precedence order in `docker/build.sh`:

1. `--nctl-bin <path>` — **internal dev**: point at a locally-built binary (any branch/SHA). Prints a warning that this isn't for public repro runs.
2. Pre-existing `./nctl` — manual override: delete the file to force re-download of the pinned version.
3. `gh release download` — **public path**: fetch pinned `NCTL_VERSION` from `github.com/nirmata/go-nctl` using the authenticated `gh` CLI.

```bash
./build.sh                              # downloads pinned release, builds all
./build.sh --only nctl                  # downloads pinned release, nctl image only
./build.sh --nctl-version v4.10.15      # override pin (for a bump PR)
./build.sh --nctl-bin /path/to/nctl     # internal dev: local build
```

## Why `gh` instead of `curl`

`nirmata/go-nctl` is a **private** repo — release assets return HTTP 404 for unauthenticated requests. Using `gh release download` handles the auth transparently; anyone with `gh auth login` against a Nirmata-linked GitHub account can run the script. Plain `curl` would require a GitHub token in an `Authorization` header, which is more setup friction for recipients.

Script exits with a clear install hint if `gh` isn't on `PATH`.

## Why pin instead of tracking `@latest`

- **Reproducibility is the benchmark's product.** A numbers table published at policy-bench commit SHA X is only meaningful if anyone can re-run it and get the same numbers. `@latest` means a run today and a run tomorrow compare against different nctl versions → no reproducibility claim.
- **Bump via PR** makes the version history traceable. Each numbers refresh can link to the PR that bumped the pin, documenting *why* we moved to vY.Z (e.g., "includes the skill patches from go-nctl#1937").
- **Speed and failure-mode reduction** are bonuses: no cross-compile, no `golang:1.26` Docker toolchain image to pull, no `go.mod` bind-mount surprises on Docker Desktop.

## Initial pin

`v4.10.14` — the current latest release. **This predates the skill-conversion fixes merged via [go-nctl#1937](https://github.com/nirmata/go-nctl/pull/1937)**, so public benchmark numbers via this path will reflect pre-patch behavior until a release containing #1937 is cut (expected v4.10.15). A follow-up PR will bump `NCTL_VERSION` at that point.

For the interim — anyone who wants to validate the post-#1937 numbers right now uses `--nctl-bin` with a binary built from go-nctl `main`. Instructions for that will land in the `#dev-ai-pac-agent` Slack announcement accompanying this PR.

## Private-repo implication for open-sourcing policy-bench

Flagging for future discussion: `nirmata/go-nctl` is currently private, so external users can't download nctl release assets even with this script. If/when policy-bench becomes truly public:

1. Either `go-nctl` also goes public (release assets become curl-able), OR
2. Binaries are mirrored somewhere public (S3, release mirror, etc.)

This PR doesn't block either path — the `build.sh` structure is compatible with both. Just worth knowing the policy-bench repo isn't automatically "open-source usable" until we solve binary distribution.

## Test plan

- [x] `bash -n docker/build.sh` syntax clean
- [x] `./build.sh --only nctl` with no existing `./nctl`: downloads `nctl_4.10.14_linux_arm64.zip` from nirmata/go-nctl release, unzips, produces a valid ELF ARM aarch64 binary
- [x] `--nctl-bin <local>` still works (internal dev path preserved)
- [ ] Docker image build after download: not re-verified in this PR (Docker daemon was unavailable at commit time); the `build_tool nctl` invocation is unchanged from before
