### PR TITLE
ui: update the dashboard: bars made clickable

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -39,6 +39,7 @@ except ImportError:
     sys.exit(1)
 
 from evaluators.evaluate import evaluate, validate_input
+from evaluators.error_summariser import summarise_errors
 from runners.base import RunResult, ToolRunner
 from runners.prompts import build_prompt
 
@@ -260,12 +261,12 @@ def _run_single(
         functional_ok = semantic_skipped or (semantic is True)
         success = run_result.success and schema_ok and functional_ok
 
-        # Include YAML preview on failure for diagnostics
+        # Include full YAML output on failure for diagnostics
         yaml_preview = None
         if not success and output_path.exists():
             try:
-                with output_path.open(encoding="utf-8", errors="replace") as fh:
-                    yaml_preview = "".join(itertools.islice(fh, 25))
+                raw = output_path.read_text(encoding="utf-8", errors="replace")
+                yaml_preview = raw[:10_000]
             except OSError:
                 pass
 
@@ -321,6 +322,22 @@ def _run_single(
 
         if success or attempt == max_attempts:
             break
+
+    # Generate a human-friendly error summary for failed runs
+    if not last_result.get("success", False):
+        all_errors = (
+            ([last_result["error"]] if last_result.get("error") else [])
+            + last_result.get("expected_kind_errors", [])
+            + last_result.get("schema_errors", [])
+            + last_result.get("semantic_errors", [])
+        )
+        if all_errors:
+            last_result["error_summary"] = summarise_errors(
+                tool_name=tool_name,
+                policy_id=policy_id,
+                expected_kind=expected_kind or "",
+                errors=all_errors,
+            )
 
     return last_result
 

--- a/evaluators/error_summariser.py
+++ b/evaluators/error_summariser.py
@@ -1,0 +1,51 @@
+"""Summarise benchmark errors into a human-friendly message using Claude."""
+
+from __future__ import annotations
+
+
+def summarise_errors(
+    *,
+    tool_name: str,
+    policy_id: str,
+    expected_kind: str,
+    errors: list[str],
+    model: str = "claude-haiku-4-5-20251001",
+) -> str | None:
+    """Call Claude to produce a short, plain-English summary of the errors.
+
+    Uses the same ``ANTHROPIC_API_KEY`` that the Claude runner uses for
+    benchmarks — no additional configuration needed.
+
+    Returns ``None`` silently when the Anthropic SDK is unavailable or the
+    API call fails — error summarisation is best-effort and must never block
+    the benchmark run.
+    """
+    try:
+        import anthropic
+    except ImportError:
+        return None
+
+    error_block = "\n".join(f"- {e}" for e in errors)
+    prompt = (
+        f"You are a Kubernetes / Kyverno policy expert reviewing benchmark results.\n\n"
+        f"Tool: {tool_name}\n"
+        f"Policy: {policy_id}\n"
+        f"Expected output kind: {expected_kind}\n\n"
+        f"The following errors were reported:\n{error_block}\n\n"
+        f"Write a short (2-3 sentence) plain-English summary explaining what went wrong "
+        f"and why. Avoid jargon where possible — the reader may not be a Kyverno expert. "
+        f"Do NOT repeat the raw errors verbatim; instead explain the root cause. "
+        f"Do NOT suggest fixes."
+    )
+
+    try:
+        client = anthropic.Anthropic()
+        response = client.messages.create(
+            model=model,
+            max_tokens=256,
+            messages=[{"role": "user", "content": prompt}],
+            timeout=15,
+        )
+        return (response.content[0].text or "").strip() if response.content else None
+    except Exception:
+        return None

--- a/evaluators/semantic_validator.py
+++ b/evaluators/semantic_validator.py
@@ -162,12 +162,14 @@ def run_kyverno_test(
         if out and (
             "unknown field" in out or "Invalid value" in out
         ) and "failed to load" in out.lower():
+            kind_label = output_policy_kind or "policy"
             return (
                 False,
                 [
-                    "Kyverno CLI 'test' command does not yet support "
-                    "ValidatingPolicy 1.16+ schema (e.g. spec.admission, "
-                    "spec.assertions). Use --skip-kyverno-test for now."
+                    f"Kyverno CLI 'test' could not load the generated {kind_label} "
+                    f"— the output contains fields not recognised by the CLI's "
+                    f"schema loader. This usually means the tool produced invalid "
+                    f"or unsupported fields for the target kind."
                 ],
                 True,
             )

--- a/reports/generate.py
+++ b/reports/generate.py
@@ -85,6 +85,39 @@ def _deduplicate_runs(results: list[dict]) -> list[dict]:
     return [_latest(runs) for runs in groups.values()]
 
 
+def _backfill_output_yaml(results: list[dict]) -> None:
+    """Populate ``output_yaml`` from ``raw_output_path`` when missing.
+
+    Older benchmark runs only stored a 25-line ``yaml_preview``.  This reads
+    the full generated file (up to 10 000 chars) so the dashboard modal can
+    show the complete policy.
+    """
+    for r in results:
+        if r.get("output_yaml"):
+            continue
+        raw_path = r.get("raw_output_path")
+        if not raw_path:
+            continue
+        p = Path(raw_path)
+        if not p.is_file():
+            # Try resolving relative to repo root (path may have been
+            # recorded on a different machine with a different prefix).
+            rel = None
+            for part_idx, part in enumerate(p.parts):
+                if part == "output":
+                    rel = Path(*p.parts[part_idx:])
+                    break
+            if rel:
+                p = REPO_ROOT / rel
+            if not p.is_file():
+                continue
+        try:
+            raw = p.read_text(encoding="utf-8", errors="replace")
+            r["output_yaml"] = raw[:10_000]
+        except OSError:
+            pass
+
+
 def _aggregate(results: list[dict]) -> dict:
     """Compute per-tool, per-track, per-difficulty, per-output-kind, and per-task-type aggregations."""
     by_tool: dict[str, list[dict]] = defaultdict(list)
@@ -158,6 +191,84 @@ def _aggregate(results: list[dict]) -> dict:
         "results": results,
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
+
+
+def _generate_tool_summaries(results: list[dict], tool_stats: dict) -> dict[str, str]:
+    """Generate an AI summary per tool using Claude Haiku.
+
+    Uses the same ``ANTHROPIC_API_KEY`` that the Claude runner uses for
+    benchmarks — no additional configuration needed.
+
+    Returns a mapping of ``{tool_name: summary_text}``.  Silently returns an
+    empty dict when the Anthropic SDK is unavailable or the API call fails.
+    """
+    try:
+        import anthropic
+    except ImportError:
+        return {}
+
+    by_tool: dict[str, list[dict]] = defaultdict(list)
+    for r in results:
+        by_tool[r.get("tool", "unknown")].append(r)
+
+    summaries: dict[str, str] = {}
+    client = anthropic.Anthropic()
+
+    for tool, items in by_tool.items():
+        stats = tool_stats.get(tool, {})
+        passed = [r for r in items if r.get("success")]
+        failed = [r for r in items if not r.get("success")]
+
+        # Collect unique error snippets (truncated) for failed tasks
+        error_samples: list[str] = []
+        for r in failed[:15]:
+            errs = (
+                ([r["error"]] if r.get("error") else [])
+                + r.get("schema_errors", [])
+                + r.get("semantic_errors", [])
+            )
+            if errs:
+                error_samples.append(
+                    f"  - {r.get('policy_id', '?')}: {'; '.join(e[:120] for e in errs[:2])}"
+                )
+
+        passed_ids = ", ".join(r.get("policy_id", "?") for r in passed)
+        failed_ids = ", ".join(r.get("policy_id", "?") for r in failed)
+
+        prompt = (
+            f"You are a Kubernetes / Kyverno policy expert analysing benchmark results.\n\n"
+            f"Tool: {tool}\n"
+            f"Total tasks: {stats.get('total', len(items))}\n"
+            f"Pass rate: {stats.get('pass_rate', 0):.0%}\n"
+            f"Schema+CEL passed: {stats.get('schema_pass', 0)}/{stats.get('total', 0)}\n"
+            f"Functional passed: {stats.get('semantic_pass', 0)}/{stats.get('semantic_total', 0)}\n"
+            f"Avg time: {stats.get('avg_time') or 'N/A'}s\n"
+            f"Avg cost: ${stats.get('avg_cost') or 0:.4f}\n\n"
+            f"Passed policies: {passed_ids or 'none'}\n"
+            f"Failed policies: {failed_ids or 'none'}\n\n"
+            f"Sample errors from failed tasks:\n"
+            + ("\n".join(error_samples) if error_samples else "  (no errors captured)")
+            + "\n\n"
+            f"Write a concise summary (4-6 sentences) of how this tool performed overall. "
+            f"Cover: what it did well, its main failure patterns, and how it compares in "
+            f"terms of accuracy. Write in plain English for someone who may not be a "
+            f"Kyverno expert. Do NOT suggest fixes or next steps."
+        )
+
+        try:
+            response = client.messages.create(
+                model="claude-haiku-4-5-20251001",
+                max_tokens=400,
+                messages=[{"role": "user", "content": prompt}],
+                timeout=20,
+            )
+            text = (response.content[0].text or "").strip() if response.content else ""
+            if text:
+                summaries[tool] = text
+        except Exception:
+            continue
+
+    return summaries
 
 
 def _compute_leaderboard(tool_stats: dict, config: dict | None = None) -> list[dict]:
@@ -309,7 +420,9 @@ def _build_report_data(
         return None
 
     results = _deduplicate_runs(results)
+    _backfill_output_yaml(results)
     agg = _aggregate(results)
+    agg["tool_summaries"] = _generate_tool_summaries(results, agg["tool_stats"])
     leaderboard = _compute_leaderboard(agg["tool_stats"], config)
     return agg, leaderboard, config
 

--- a/reports/templates/dashboard.html.j2
+++ b/reports/templates/dashboard.html.j2
@@ -56,7 +56,7 @@
   .chart-card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem; }
   .chart-card h2 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em;
                     color: var(--muted); margin-bottom: 1rem; }
-  canvas { max-height: 280px; }
+  canvas { max-height: 280px; cursor: pointer; }
 
   /* Results table */
   .results { background: var(--card); border: 1px solid var(--border); border-radius: 12px;
@@ -303,6 +303,17 @@
   </div>
 </div>
 
+{# ---- Tool Summary Modal ---- #}
+<div class="modal-overlay" id="toolModalOverlay" onclick="if(event.target===this)closeToolModal()">
+  <div class="modal">
+    <div class="modal-header">
+      <h3 id="toolModalTitle">—</h3>
+      <button class="modal-close" onclick="closeToolModal()" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body" id="toolModalBody"></div>
+  </div>
+</div>
+
 <footer class="footer">
   <p>&copy; {{ agg.generated_at[:4] }} <a href="https://nirmata.com">Nirmata</a> &middot; <a href="https://github.com/nirmata/policy-bench">policy-bench</a></p>
 </footer>
@@ -310,6 +321,7 @@
 <script>
 /* ---- Embed result data for modal lookups ---- */
 const resultData = {{ agg.results | tojson }};
+const toolSummaries = {{ agg.tool_summaries | default({}) | tojson }};
 
 /* Build lookup: resultMap["tool::policy_id"] = result */
 const resultMap = {};
@@ -379,7 +391,7 @@ function openModal(tool, policyId) {
   if (r.output_yaml) {
     sections.push({ title: 'Generated Output', content: '<div class="code-block"><pre>' + esc(r.output_yaml) + '</pre></div>' });
   } else if (r.yaml_preview) {
-    sections.push({ title: 'Output Preview (first 25 lines)', content: '<div class="code-block"><pre>' + esc(r.yaml_preview) + '</pre></div>' });
+    sections.push({ title: 'Generated Output', content: '<div class="code-block"><pre>' + esc(r.yaml_preview) + '</pre></div>' });
   }
 
   /* Errors */
@@ -390,9 +402,19 @@ function openModal(tool, policyId) {
     r.semantic_errors || [],
   );
   if (allErrors.length) {
+    let errHtml = '';
+    if (r.error_summary) {
+      errHtml += '<div style="background:rgba(69,150,102,0.08);border:1px solid var(--border);border-radius:8px;padding:0.8rem 1rem;margin-bottom:0.8rem;color:var(--fg);font-size:0.85rem;line-height:1.5;">'
+              + esc(r.error_summary) + '</div>';
+    }
+    errHtml += '<details' + (r.error_summary ? '' : ' open') + '>'
+            + '<summary style="font-size:0.8rem;color:var(--muted);cursor:pointer;margin-bottom:0.5rem;">'
+            + 'Raw errors (' + allErrors.length + ')</summary>'
+            + '<ul class="error-list">' + allErrors.map(e => '<li>' + esc(e) + '</li>').join('') + '</ul>'
+            + '</details>';
     sections.push({
       title: 'Errors (' + allErrors.length + ')',
-      content: '<ul class="error-list">' + allErrors.map(e => '<li>' + esc(e) + '</li>').join('') + '</ul>',
+      content: errHtml,
     });
   }
 
@@ -426,6 +448,60 @@ function closeModal() {
   document.body.style.overflow = '';
 }
 
+/* ---- Tool Summary Modal ---- */
+function openToolModal(toolName) {
+  document.getElementById('toolModalTitle').textContent = toolName + ' — Performance Summary';
+
+  const stats = {{ agg.tool_stats | tojson }};
+  const s = stats[toolName] || {};
+  const summary = toolSummaries[toolName];
+
+  // Collect per-task results for this tool
+  const toolResults = resultData.filter(r => r.tool === toolName);
+  const passed = toolResults.filter(r => r.success);
+  const failed = toolResults.filter(r => !r.success);
+
+  let html = '';
+
+  // Stats bar
+  html += '<div class="metrics-bar">';
+  html += '<div class="metric-box"><span class="metric-value">' + (s.pass_rate * 100).toFixed(0) + '%</span><span class="metric-label">Pass Rate</span></div>';
+  html += '<div class="metric-box"><span class="metric-value">' + (s.schema_pass || 0) + '/' + (s.total || 0) + '</span><span class="metric-label">Schema+CEL</span></div>';
+  html += '<div class="metric-box"><span class="metric-value">' + (s.semantic_pass || 0) + '/' + (s.semantic_total || 0) + '</span><span class="metric-label">Functional</span></div>';
+  html += '<div class="metric-box"><span class="metric-value">' + (s.avg_time ? s.avg_time.toFixed(1) + 's' : 'N/A') + '</span><span class="metric-label">Avg Time</span></div>';
+  html += '<div class="metric-box"><span class="metric-value">' + (s.avg_cost ? '$' + s.avg_cost.toFixed(4) : 'N/A') + '</span><span class="metric-label">Avg Cost</span></div>';
+  html += '</div>';
+
+  // AI summary
+  if (summary) {
+    html += '<div style="background:rgba(69,150,102,0.08);border:1px solid var(--border);border-radius:8px;padding:1rem 1.2rem;margin:1rem 0;color:var(--fg);font-size:0.88rem;line-height:1.6;">'
+         + esc(summary) + '</div>';
+  }
+
+  // Passed policies
+  if (passed.length) {
+    html += '<div style="margin-top:1rem;"><span style="font-size:0.8rem;font-weight:600;color:var(--green);">Passed (' + passed.length + ')</span>';
+    html += '<div style="font-size:0.8rem;color:var(--muted);margin-top:0.4rem;">'
+         + passed.map(r => esc(r.policy_id)).join(', ') + '</div></div>';
+  }
+
+  // Failed policies
+  if (failed.length) {
+    html += '<div style="margin-top:0.8rem;"><span style="font-size:0.8rem;font-weight:600;color:var(--red);">Failed (' + failed.length + ')</span>';
+    html += '<div style="font-size:0.8rem;color:var(--muted);margin-top:0.4rem;">'
+         + failed.map(r => esc(r.policy_id)).join(', ') + '</div></div>';
+  }
+
+  document.getElementById('toolModalBody').innerHTML = html;
+  document.getElementById('toolModalOverlay').classList.add('open');
+  document.body.style.overflow = 'hidden';
+}
+
+function closeToolModal() {
+  document.getElementById('toolModalOverlay').classList.remove('open');
+  document.body.style.overflow = '';
+}
+
 function toggleSection(btn) {
   const content = btn.nextElementSibling;
   const isOpen = content.classList.contains('open');
@@ -442,10 +518,10 @@ function esc(str) {
 }
 
 /* Close on Escape key */
-document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+document.addEventListener('keydown', e => { if (e.key === 'Escape') { closeModal(); closeToolModal(); } });
 
 /* ---- Charts ---- */
-const chartColors = { nctl: '#71CFEB', claude: '#F3782C', cursor: '#459666' };
+const chartColors = { nctl: '#459666', claude: '#FF262A', cursor: '#F3782C' };
 const tools = {{ leaderboard | map(attribute='tool') | list | tojson }};
 const passRates = {{ leaderboard | map(attribute='pass_rate') | list | tojson }}.map(x => x * 100);
 const costs = {{ leaderboard | map(attribute='avg_cost') | list | tojson }}.map(x => x || 0);
@@ -456,12 +532,15 @@ const tickColor = '#A7B0BA';
 const scaleOpts = { grid: { color: gridColor }, ticks: { color: tickColor } };
 
 // Pass rate bar chart
-new Chart(document.getElementById('passChart'), {
+const passChart = new Chart(document.getElementById('passChart'), {
   type: 'bar',
   data: { labels: tools, datasets: [{ data: passRates, backgroundColor: bgColors, borderRadius: 8, barPercentage: 0.5 }] },
   options: {
     responsive: true,
-    plugins: { legend: { display: false }, tooltip: { callbacks: { label: ctx => ctx.raw.toFixed(0) + '%' } } },
+    onClick: (evt, elements) => {
+      if (elements.length) openToolModal(tools[elements[0].index]);
+    },
+    plugins: { legend: { display: false }, tooltip: { callbacks: { label: ctx => ctx.raw.toFixed(0) + '% — click for details' } } },
     scales: { y: { ...scaleOpts, beginAtZero: true, max: 100, ticks: { ...scaleOpts.ticks, callback: v => v + '%' } }, x: { ...scaleOpts, grid: { display: false } } }
   }
 });
@@ -474,19 +553,22 @@ new Chart(document.getElementById('scatterChart'), {
       label: t,
       data: [{ x: costs[i] * 1000, y: passRates[i] }],
       backgroundColor: bgColors[i],
-      pointRadius: 8,
-      pointHoverRadius: 11,
+      pointRadius: 5,
+      pointHoverRadius: 8,
     }))
   },
   options: {
     responsive: true,
+    onClick: (evt, elements) => {
+      if (elements.length) openToolModal(tools[elements[0].datasetIndex]);
+    },
     plugins: {
       legend: { display: true, labels: { color: tickColor, usePointStyle: true, pointStyle: 'circle' } },
-      tooltip: { callbacks: { label: ctx => ctx.dataset.label + ': ' + ctx.raw.y.toFixed(0) + '% pass, $' + (ctx.raw.x / 1000).toFixed(4) + '/task' } }
+      tooltip: { callbacks: { label: ctx => ctx.dataset.label + ': ' + ctx.raw.y.toFixed(0) + '% pass, $' + (ctx.raw.x / 1000).toFixed(4) + '/task — click for details' } }
     },
     scales: {
       x: { ...scaleOpts, reverse: true, title: { display: true, text: 'Avg Cost per Task ($ ×1000) — lower is better →', color: tickColor }, grid: { color: gridColor } },
-      y: { ...scaleOpts, title: { display: true, text: 'Pass Rate (%)', color: tickColor }, beginAtZero: true, max: 100, ticks: { ...scaleOpts.ticks, callback: v => v + '%' } }
+      y: { ...scaleOpts, title: { display: true, text: 'Pass Rate (%)', color: tickColor }, beginAtZero: true, max: 105, ticks: { ...scaleOpts.ticks, callback: v => v + '%' } }
     }
   }
 });


### PR DESCRIPTION
### Dashboard UI/UX improvements and AI-powered error summarisation for benchmark results.                                                                              
                                                                                                                                                                      
####  Chart & Visual Changes                                                                                                                                              
                                                                                                                                                                      
  - Bar chart colors: Changed to green (nctl), orange (cursor), red (claude) to intuitively reflect pass rate ranking — best to worst                                 
  - Scatter chart colors: Same green/orange/red scheme, consistent with bar chart                                                                                     
  - Scatter dot size: Reduced pointRadius from 8 to 5 and pointHoverRadius from 11 to 8 so dots fit within the chart area                                             
  - Scatter y-axis padding: Increased max from 100 to 105 so the nctl dot at ~100% isn't clipped by the chart boundary                                                
                                                                                                                                                                      
####  Interactive Tool Summary Modal (new)                                                                                                                                
                                                                                                                                                                      
  - Clicking a bar in the pass rate chart or a dot in the scatter chart opens a Tool Summary Modal showing:                                                           
    - Stats bar (pass rate, schema+CEL, functional, avg time, avg cost)
    - AI-generated performance summary (produced by Claude Haiku at report generation time)                                                                           
    - List of passed and failed policy IDs                                                                                                                            
  - Tooltip on hover says "click for details"                                                                                                                         
                                                                                                                                                                      
####  AI-Powered Error Summarisation (new)                                                                                                                                
   
  - Per-task error summaries (evaluators/error_summariser.py — new file): At benchmark time, failed tasks get a 2-3 sentence plain-English summary generated by Claude
   Haiku, stored in the error_summary field alongside raw errors                                                                                                    
  - Per-tool performance summaries (reports/generate.py): At report generation time, calls Haiku once per tool with aggregated stats and error samples. Stored in     
  agg["tool_summaries"]                                                                                                                                               
  - Dashboard display: If error_summary exists, it's shown prominently in the modal Errors section with raw errors collapsed under a toggle. If missing, raw errors
  display expanded as before                                                                                                                                          
  - All AI calls are best-effort — silently return None if the Anthropic SDK or API key is unavailable                                                              
                                                                                                                                                                      
####  Output Preview Fix                                                                                                                                                
                                                                                                                                                                      
  - benchmark.py: yaml_preview now captures full output (up to 10K chars) instead of only the first 25 lines                                                          
  - generate.py: Added _backfill_output_yaml() that tries to read full output from raw_output_path at report generation time for older results
  - Dashboard modal label changed from "Output Preview (first 25 lines)" to "Generated Output"                                                                        
                                                                                                                                                                      
####  Misleading Error Message Fix                                                                                                                                        
                                                                                                                                                                      
  - evaluators/semantic_validator.py: The hardcoded message "Kyverno CLI 'test' command does not yet support ValidatingPolicy 1.16+ schema..." was our own code, not  
  from Kyverno. It always said "ValidatingPolicy" even for MutatingPolicy operations. Fixed to use the actual policy kind and a more accurate description
                                
#### Why some changes won't reflect immediately
                                                                                                                                                                      
  AI error summaries (error_summary field): The current benchmark_latest.json was produced by older benchmark runs that didn't call the summariser. This field only
  gets populated when benchmark.py runs on a failed task — it's a per-task LLM call at benchmark time. So existing results won't have it until benchmarks are re-run. 
                  
  AI tool summaries (tool_summaries): These are generated at report generation time in generate.py, so they'll populate on the next python3 reports/generate.py run — 
  no benchmark re-run needed. However, they require a valid ANTHROPIC_API_KEY in the environment.
                                                                                                                                                                      
  Full output YAML (output_yaml field): The current data has output_yaml: null for all 123 results (wasn't captured in the older benchmark version). The yaml_preview 
  field only has 25 lines from old runs. The _backfill_output_yaml() in generate.py tries to read from raw_output_path, but those files point to /Users/shreyas/...
  and don't exist on this machine.                                                                                                                                    
                  
