### PR TITLE
feat: Kyverno CLI test generation benchmark (issue #20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ dataset/.cache/
 dataset/imported/**
 !dataset/imported/README.md
 !dataset/imported/upstream-meta.json
+.gitnexus

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,3 @@ dataset/.cache/
 dataset/imported/**
 !dataset/imported/README.md
 !dataset/imported/upstream-meta.json
-.gitnexus

--- a/benchmark.py
+++ b/benchmark.py
@@ -4,9 +4,10 @@ Policy as Code Benchmark — main orchestrator.
 
   dataset → run tools → collect outputs → evaluate → store JSON → generate report
 
-Supports two task types:
+Supports three task types:
   - **convert** — source policy → converted output (schema+CEL + functional test)
   - **generate** — natural-language prompt → new policy (schema+CEL + functional test)
+  - **generate_test** — source policy → kyverno-test.yaml + resources.yaml (schema + kyverno test + coverage)
 
 Usage:
   python3 benchmark.py                                   # all tools, all policies
@@ -16,6 +17,7 @@ Usage:
   python3 benchmark.py --tool nctl --max-attempts 3      # iterative improvement
   python3 benchmark.py --difficulty stress               # stress tests only
   python3 benchmark.py --task-type generate              # generation tasks only
+  python3 benchmark.py --task-type generate_test         # test-generation tasks only
   python3 benchmark.py --output-kind MutatingPolicy      # filter by target kind
   python3 benchmark.py --report                          # generate report from existing results
 """
@@ -40,6 +42,7 @@ except ImportError:
 
 from evaluators.evaluate import evaluate, validate_input
 from evaluators.error_summariser import summarise_errors
+from evaluators.testgen_validator import evaluate_testgen
 from runners.base import RunResult, ToolRunner
 from runners.prompts import build_prompt
 
@@ -144,6 +147,7 @@ def _run_single(
     policy_id = policy["id"]
     task_type = policy.get("task_type", "convert")
     is_generate = task_type == "generate"
+    is_testgen = task_type == "generate_test"
     expect_failure = policy.get("expect_failure", False)
 
     input_path: Path | None = None
@@ -164,8 +168,8 @@ def _run_single(
             "error": f"Dataset file not found: {input_path}.{hint}",
         }
 
-    # Validate input (skip for generation tasks and stress tests)
-    if not is_generate and not expect_failure and input_path:
+    # Validate input (skip for generation/test-gen tasks and stress tests)
+    if not is_generate and not is_testgen and not expect_failure and input_path:
         in_pass, in_errors = validate_input(
             track, input_path, use_kubectl=eval_config.get("kubectl_dry_run", True),
         )
@@ -180,8 +184,16 @@ def _run_single(
             }
 
     output_dir = REPO_ROOT / "output" / tool_name
-    output_path = output_dir / f"{policy_id}.yaml"
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if is_testgen:
+        output_path = output_dir / policy_id  # directory, not a file
+        output_path.mkdir(parents=True, exist_ok=True)
+        # Copy source policy into the output dir so kyverno test can reference
+        # it as policies: [policy.yaml] — no ../.. path games needed.
+        if input_path:
+            shutil.copy2(input_path, output_path / "policy.yaml")
+    else:
+        output_path = output_dir / f"{policy_id}.yaml"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
     timeout = eval_config.get("timeout_seconds", 120)
     expected_kind = policy.get("expected_output_kind")
@@ -242,38 +254,62 @@ def _run_single(
             kyverno_test_dir = REPO_ROOT / "dataset" / policy["kyverno_test_dir"]
 
         eval_result: dict = {}
-        if run_result.success and output_path.exists():
-            eval_result = evaluate(
-                track,
-                input_path,
-                output_path,
-                expected_output_kind=expected_kind,
-                skip_kyverno_test=eval_config.get("skip_kyverno_test", False),
-                kyverno_test_dir=kyverno_test_dir,
-                task_type=task_type,
-            )
+        if is_testgen:
+            if run_result.success and output_path.is_dir():
+                eval_result = evaluate_testgen(
+                    generated_dir=output_path,
+                    source_policy=input_path or output_path / "policy.yaml",
+                    oracle_dir=kyverno_test_dir,
+                    timeout_sec=timeout,
+                )
+            elif kyverno_test_dir:
+                # No output directory produced — penalise same as a failed run
+                eval_result = {
+                    "testgen_composite_pass": False,
+                    "testgen_schema_pass": False,
+                    "testgen_errors": ["No output directory produced by tool"],
+                    "schema_pass": False,
+                    "semantic_pass": False,
+                    "semantic_skipped": False,
+                    "semantic_errors": ["No output produced by tool"],
+                }
+        else:
+            if run_result.success and output_path.exists():
+                eval_result = evaluate(
+                    track,
+                    input_path,
+                    output_path,
+                    expected_output_kind=expected_kind,
+                    skip_kyverno_test=eval_config.get("skip_kyverno_test", False),
+                    kyverno_test_dir=kyverno_test_dir,
+                    task_type=task_type,
+                )
+            # If tool failed to produce output but a functional test exists,
+            # mark functional as failed (not skipped) — no output is worse than
+            # wrong output and should count against the tool's score.
+            if not eval_result and kyverno_test_dir:
+                eval_result["semantic_pass"] = False
+                eval_result["semantic_skipped"] = False
+                eval_result["semantic_errors"] = ["No output produced by tool"]
 
-        # If tool failed to produce output but a functional test exists,
-        # mark functional as failed (not skipped) — no output is worse than
-        # wrong output and should count against the tool's score.
-        if not eval_result and kyverno_test_dir:
-            eval_result["semantic_pass"] = False
-            eval_result["semantic_skipped"] = False
-            eval_result["semantic_errors"] = ["No output produced by tool"]
+        if is_testgen:
+            success = run_result.success and eval_result.get("testgen_composite_pass", False)
+        else:
+            schema_ok = eval_result.get("schema_pass", False)
+            semantic = eval_result.get("semantic_pass")
+            semantic_skipped = eval_result.get("semantic_skipped", True)
+            functional_ok = semantic_skipped or (semantic is True)
+            success = run_result.success and schema_ok and functional_ok
 
-        # Success = tool ran + schema/CEL pass + functional pass (or skipped)
-        schema_ok = eval_result.get("schema_pass", False)
-        semantic = eval_result.get("semantic_pass")
-        semantic_skipped = eval_result.get("semantic_skipped", True)
-        functional_ok = semantic_skipped or (semantic is True)
-        success = run_result.success and schema_ok and functional_ok
+        # For test-gen tasks the canonical output file is kyverno-test.yaml inside the dir.
+        output_yaml_path = (output_path / "kyverno-test.yaml") if is_testgen else output_path
 
         # Include full YAML output on failure for diagnostics
         yaml_preview = None
-        if not success and output_path.exists():
+        if not success:
             try:
-                raw = output_path.read_text(encoding="utf-8", errors="replace")
-                yaml_preview = raw[:10_000]
+                if output_yaml_path.exists():
+                    yaml_preview = output_yaml_path.read_text(encoding="utf-8", errors="replace")[:10_000]
             except OSError:
                 pass
 
@@ -288,12 +324,11 @@ def _run_single(
 
         # Capture generated output YAML
         output_yaml = None
-        if output_path.exists():
-            try:
-                raw = output_path.read_text(encoding="utf-8", errors="replace")
-                output_yaml = raw[:10_000]
-            except OSError:
-                pass
+        try:
+            if output_yaml_path.exists():
+                output_yaml = output_yaml_path.read_text(encoding="utf-8", errors="replace")[:10_000]
+        except OSError:
+            pass
 
         timestamp_str = datetime.now(timezone.utc).isoformat()
         last_result = {
@@ -316,7 +351,7 @@ def _run_single(
             "tokens_estimated": run_result.tokens_estimated,
             "model": run_result.model,
             "tool_version": run_result.tool_version,
-            "raw_output_path": str(output_path),
+            "raw_output_path": str(output_yaml_path),
             "attempt": attempt,
             "max_attempts": max_attempts,
             **eval_result,
@@ -436,7 +471,7 @@ def main() -> int:
     parser.add_argument("--track", help="Filter by conversion track")
     parser.add_argument("--policy-id", nargs="+", help="Run one or more policies by ID")
     parser.add_argument("--difficulty", help="Filter by difficulty (easy, medium, hard, stress)")
-    parser.add_argument("--task-type", choices=["convert", "generate"], help="Filter by task type")
+    parser.add_argument("--task-type", choices=["convert", "generate", "generate_test"], help="Filter by task type")
     parser.add_argument("--output-kind", help="Filter by expected output kind (e.g. MutatingPolicy)")
     parser.add_argument("--max-attempts", type=int, default=1, help="Max attempts per policy (iterative improvement)")
     parser.add_argument("--workers", type=int, default=1, help="Parallel workers per tool (default: 1 = sequential)")

--- a/config.yaml
+++ b/config.yaml
@@ -67,6 +67,10 @@ task_types:
     description: "Generate a new policy from a natural-language description"
     requires_input: false
     evaluations: [schema, semantic]
+  generate_test:
+    description: "Generate a Kyverno CLI test suite for an existing policy"
+    requires_input: true
+    evaluations: [schema, semantic, coverage]
 
 evaluation:
   skip_kyverno_test: false

--- a/dataset/index.yaml
+++ b/dataset/index.yaml
@@ -348,3 +348,63 @@ policies:
   description: generates a NetworkPolicy named 'default-deny' in any newly-created Namespace. The generated NetworkPolicy
     must select all Pods (empty podSelector), include both 'Ingress' and 'Egress' policyTypes, and define no ingress or egress
     rules so all traffic is denied by default.
+
+# ======================================================================
+# Test-generation tasks (task_type: generate_test)
+#
+# Given an existing Kyverno policy, write a kyverno-test.yaml + resources.yaml
+# test suite that exercises the policy.  The oracle in kyverno_test_dir is used
+# for coverage scoring (generated vs oracle tuple counts, has_pass_and_fail).
+# ======================================================================
+- id: tg_cp_require_labels
+  track: kyverno-test-gen
+  task_type: generate_test
+  difficulty: easy
+  expected_output_kind: null
+  path: imported/kyverno-policies/cp_require_labels.yaml
+  kyverno_test_dir: imported/kyverno-tests/cp_require_labels
+  description: define and use labels that identify semantic attributes of your application or Deployment
+- id: tg_cp_disallow_default_namespace
+  track: kyverno-test-gen
+  task_type: generate_test
+  difficulty: medium
+  expected_output_kind: null
+  path: imported/kyverno-policies/cp_disallow_default_namespace.yaml
+  kyverno_test_dir: imported/kyverno-tests/cp_disallow_default_namespace
+  description: kubernetes Namespaces are an optional feature that provide a way to segment and isolate cluster resources across
+    multiple applications and users
+- id: tg_cp_require_drop_all
+  track: kyverno-test-gen
+  task_type: generate_test
+  difficulty: medium
+  expected_output_kind: null
+  path: imported/kyverno-policies/cp_require_drop_all.yaml
+  kyverno_test_dir: imported/kyverno-tests/cp_require_drop_all
+  description: capabilities permit privileged actions without giving full root access
+- id: tg_cp_inject_sidecar
+  track: kyverno-test-gen
+  task_type: generate_test
+  difficulty: medium
+  expected_output_kind: null
+  path: imported/kyverno-policies/cp_inject_sidecar.yaml
+  kyverno_test_dir: imported/kyverno-tests/cp_inject_sidecar
+  description: the sidecar pattern is very common in Kubernetes whereby other applications can insert components via admission
+    control into matched Deployments
+- id: tg_cp_kasten_generate_backup
+  track: kyverno-test-gen
+  task_type: generate_test
+  difficulty: hard
+  expected_output_kind: null
+  path: imported/kyverno-policies/cp_kasten_generate_backup.yaml
+  kyverno_test_dir: imported/kyverno-tests/cp_kasten_generate_backup
+  description: generates a Kasten policy for a namespace that includes any Deployment or StatefulSet with a "dataprotection"
+    label
+- id: tg_vpol_block_ephemeral_containers
+  track: kyverno-test-gen
+  task_type: generate_test
+  difficulty: easy
+  expected_output_kind: null
+  path: imported/kyverno-policies/vpol_block_ephemeral_containers.yaml
+  kyverno_test_dir: imported/kyverno-tests/vpol_block_ephemeral_containers
+  description: native ValidatingPolicy (policies.kyverno.io/v1) that blocks ephemeral debug containers from being attached
+    to Pods

--- a/dataset/kyverno-upstream-manifest.yaml
+++ b/dataset/kyverno-upstream-manifest.yaml
@@ -182,3 +182,13 @@ policies:
   - id: gen_disallow_capabilities
     upstream_path: pod-security/baseline/disallow-capabilities/disallow-capabilities.yaml
     sync_test: true
+
+  # =====================================================================
+  # Native ValidatingPolicy sources — for generate_test benchmark tasks.
+  # These are already in the new policies.kyverno.io/v1 format, so the
+  # test-gen benchmark can measure generation against a modern policy kind.
+  # =====================================================================
+
+  - id: vpol_block_ephemeral_containers
+    upstream_path: other-vpol/block-ephemeral-containers/block-ephemeral-containers.yaml
+    sync_test: true

--- a/evaluators/test_testgen_validator.py
+++ b/evaluators/test_testgen_validator.py
@@ -1,0 +1,366 @@
+"""Unit tests for testgen_validator.evaluate_testgen()."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from evaluators.testgen_validator import (
+    _count_tuples,
+    _has_pass_and_fail,
+    evaluate_testgen,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_MANIFEST = textwrap.dedent("""\
+    apiVersion: cli.kyverno.io/v1alpha1
+    kind: Test
+    metadata:
+      name: require-labels
+    policies:
+    - policy.yaml
+    resources:
+    - resources.yaml
+    results:
+    - kind: Pod
+      policy: require-labels
+      resources:
+      - goodpod
+      result: pass
+      rule: check-for-labels
+    - kind: Pod
+      policy: require-labels
+      resources:
+      - badpod
+      result: fail
+      rule: check-for-labels
+""")
+
+_VALID_RESOURCES = textwrap.dedent("""\
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: goodpod
+""")
+
+_SOURCE_POLICY = textwrap.dedent("""\
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      name: require-labels
+""")
+
+
+def _write_suite(tmp_path: Path, manifest: str = _VALID_MANIFEST, resources: str = _VALID_RESOURCES) -> Path:
+    suite_dir = tmp_path / "suite"
+    suite_dir.mkdir()
+    (suite_dir / "kyverno-test.yaml").write_text(manifest)
+    (suite_dir / "resources.yaml").write_text(resources)
+    return suite_dir
+
+
+def _write_source(tmp_path: Path, content: str = _SOURCE_POLICY) -> Path:
+    p = tmp_path / "policy.yaml"
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _count_tuples
+# ---------------------------------------------------------------------------
+
+def test_count_tuples_multi_resource():
+    results = [
+        {"resources": ["a", "b"], "result": "fail"},
+        {"resources": ["c"], "result": "pass"},
+    ]
+    assert _count_tuples(results) == 3
+
+
+def test_count_tuples_no_resources_field():
+    # An entry with no resources list counts as 1.
+    assert _count_tuples([{"result": "pass"}]) == 1
+
+
+def test_count_tuples_empty():
+    assert _count_tuples([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# _has_pass_and_fail
+# ---------------------------------------------------------------------------
+
+def test_has_pass_and_fail_true():
+    results = [{"result": "pass"}, {"result": "fail"}]
+    assert _has_pass_and_fail(results) is True
+
+
+def test_has_pass_and_fail_pass_only():
+    assert _has_pass_and_fail([{"result": "pass"}]) is False
+
+
+def test_has_pass_and_fail_skip_doesnt_count():
+    results = [{"result": "pass"}, {"result": "skip"}]
+    assert _has_pass_and_fail(results) is False
+
+
+# ---------------------------------------------------------------------------
+# evaluate_testgen: missing files
+# ---------------------------------------------------------------------------
+
+def test_missing_kyverno_test_yaml(tmp_path):
+    suite_dir = tmp_path / "suite"
+    suite_dir.mkdir()
+    (suite_dir / "resources.yaml").write_text(_VALID_RESOURCES)
+    source = _write_source(tmp_path)
+    result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    assert result["testgen_schema_pass"] is False
+    assert result["testgen_composite_pass"] is False
+    assert any("kyverno-test.yaml" in e for e in result["testgen_errors"])
+
+
+def test_missing_resources_yaml(tmp_path):
+    suite_dir = tmp_path / "suite"
+    suite_dir.mkdir()
+    (suite_dir / "kyverno-test.yaml").write_text(_VALID_MANIFEST)
+    source = _write_source(tmp_path)
+    result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    assert result["testgen_schema_pass"] is False
+    assert any("resources.yaml" in e for e in result["testgen_errors"])
+
+
+# ---------------------------------------------------------------------------
+# evaluate_testgen: schema failures
+# ---------------------------------------------------------------------------
+
+def test_wrong_api_version(tmp_path):
+    bad_manifest = _VALID_MANIFEST.replace(
+        "cli.kyverno.io/v1alpha1", "cli.kyverno.io/v1beta1"
+    )
+    suite_dir = _write_suite(tmp_path, manifest=bad_manifest)
+    source = _write_source(tmp_path)
+    with patch("evaluators.testgen_validator.run_kyverno_test") as mock_kt:
+        mock_kt.return_value = (True, [], False)
+        result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    assert result["testgen_schema_pass"] is False
+    assert result["testgen_composite_pass"] is False
+
+
+def test_missing_results_field(tmp_path):
+    bad_manifest = textwrap.dedent("""\
+        apiVersion: cli.kyverno.io/v1alpha1
+        kind: Test
+        metadata:
+          name: x
+        policies:
+        - policy.yaml
+        resources:
+        - resources.yaml
+    """)
+    suite_dir = _write_suite(tmp_path, manifest=bad_manifest)
+    source = _write_source(tmp_path)
+    result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    assert result["testgen_schema_pass"] is False
+    assert any("results" in e for e in result["testgen_errors"])
+
+
+# ---------------------------------------------------------------------------
+# evaluate_testgen: functional failures
+# ---------------------------------------------------------------------------
+
+def test_kyverno_test_fails(tmp_path):
+    suite_dir = _write_suite(tmp_path)
+    source = _write_source(tmp_path)
+    with patch("evaluators.testgen_validator.run_kyverno_test") as mock_kt:
+        mock_kt.return_value = (False, ["assertion failed"], False)
+        result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    assert result["testgen_schema_pass"] is True
+    assert result["testgen_kyverno_test_pass"] is False
+    assert result["testgen_composite_pass"] is False
+    assert "assertion failed" in result["testgen_errors"]
+
+
+def test_kyverno_test_skipped(tmp_path):
+    suite_dir = _write_suite(tmp_path)
+    source = _write_source(tmp_path)
+    with patch("evaluators.testgen_validator.run_kyverno_test") as mock_kt:
+        mock_kt.return_value = (False, [], True)
+        result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    assert result["testgen_kyverno_test_skipped"] is True
+    assert result["testgen_kyverno_test_pass"] is None
+    # Skipped kyverno test → composite fails (no evidence it ran correctly)
+    assert result["testgen_composite_pass"] is False
+
+
+# ---------------------------------------------------------------------------
+# evaluate_testgen: coverage computation
+# ---------------------------------------------------------------------------
+
+def test_coverage_score_with_oracle(tmp_path):
+    suite_dir = _write_suite(tmp_path)
+    source = _write_source(tmp_path)
+
+    # Oracle has 4 tuples (2 entries × 2 resources each)
+    oracle_dir = tmp_path / "oracle"
+    oracle_dir.mkdir()
+    oracle_manifest = textwrap.dedent("""\
+        apiVersion: cli.kyverno.io/v1alpha1
+        kind: Test
+        metadata:
+          name: require-labels
+        policies:
+        - policy.yaml
+        resources:
+        - resources.yaml
+        results:
+        - kind: Pod
+          policy: require-labels
+          resources: [a, b]
+          result: pass
+          rule: check-for-labels
+        - kind: Pod
+          policy: require-labels
+          resources: [c, d]
+          result: fail
+          rule: check-for-labels
+    """)
+    (oracle_dir / "kyverno-test.yaml").write_text(oracle_manifest)
+
+    with patch("evaluators.testgen_validator.run_kyverno_test") as mock_kt:
+        mock_kt.return_value = (True, [], False)
+        result = evaluate_testgen(
+            generated_dir=suite_dir,
+            source_policy=source,
+            oracle_dir=oracle_dir,
+        )
+
+    # Generated suite has 2 tuples (1 resource each), oracle has 4 → 0.5
+    assert result["testgen_oracle_tuples"] == 4
+    assert result["testgen_generated_tuples"] == 2
+    assert result["testgen_coverage_score"] == 0.5
+
+
+def test_coverage_score_capped_at_1(tmp_path):
+    """Generated suite covering MORE than the oracle still scores 1.0."""
+    # Build a generated suite with 3 tuples
+    big_manifest = textwrap.dedent("""\
+        apiVersion: cli.kyverno.io/v1alpha1
+        kind: Test
+        metadata:
+          name: require-labels
+        policies:
+        - policy.yaml
+        resources:
+        - resources.yaml
+        results:
+        - kind: Pod
+          policy: require-labels
+          resources: [a, b, c]
+          result: pass
+          rule: check-for-labels
+        - kind: Pod
+          policy: require-labels
+          resources: [d]
+          result: fail
+          rule: check-for-labels
+    """)
+    suite_dir = _write_suite(tmp_path, manifest=big_manifest)
+    source = _write_source(tmp_path)
+
+    oracle_dir = tmp_path / "oracle"
+    oracle_dir.mkdir()
+    (oracle_dir / "kyverno-test.yaml").write_text(textwrap.dedent("""\
+        apiVersion: cli.kyverno.io/v1alpha1
+        kind: Test
+        metadata:
+          name: x
+        policies: [p]
+        resources: [r]
+        results:
+        - resources: [x]
+          result: pass
+        - resources: [y]
+          result: fail
+    """))
+
+    with patch("evaluators.testgen_validator.run_kyverno_test") as mock_kt:
+        mock_kt.return_value = (True, [], False)
+        result = evaluate_testgen(
+            generated_dir=suite_dir, source_policy=source, oracle_dir=oracle_dir
+        )
+
+    assert result["testgen_coverage_score"] == 1.0
+
+
+def test_no_oracle_coverage_zero(tmp_path):
+    suite_dir = _write_suite(tmp_path)
+    source = _write_source(tmp_path)
+    with patch("evaluators.testgen_validator.run_kyverno_test") as mock_kt:
+        mock_kt.return_value = (True, [], False)
+        result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    assert result["testgen_coverage_score"] == 0.0
+    assert result["testgen_oracle_tuples"] == 0
+
+
+# ---------------------------------------------------------------------------
+# evaluate_testgen: composite formula
+# ---------------------------------------------------------------------------
+
+def test_composite_pass_all_three_signals(tmp_path):
+    suite_dir = _write_suite(tmp_path)
+    source = _write_source(tmp_path)
+    with patch("evaluators.testgen_validator.run_kyverno_test") as mock_kt:
+        mock_kt.return_value = (True, [], False)
+        result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    # Valid schema + kyverno test passes + has pass and fail → composite True
+    assert result["testgen_schema_pass"] is True
+    assert result["testgen_kyverno_test_pass"] is True
+    assert result["testgen_has_pass_and_fail"] is True
+    assert result["testgen_composite_pass"] is True
+
+
+def test_composite_fails_without_pass_and_fail(tmp_path):
+    """A suite with only passing cases should not earn composite_pass."""
+    pass_only_manifest = textwrap.dedent("""\
+        apiVersion: cli.kyverno.io/v1alpha1
+        kind: Test
+        metadata:
+          name: x
+        policies:
+        - policy.yaml
+        resources:
+        - resources.yaml
+        results:
+        - kind: Pod
+          policy: x
+          resources: [goodpod]
+          result: pass
+          rule: some-rule
+    """)
+    suite_dir = _write_suite(tmp_path, manifest=pass_only_manifest)
+    source = _write_source(tmp_path)
+    with patch("evaluators.testgen_validator.run_kyverno_test") as mock_kt:
+        mock_kt.return_value = (True, [], False)
+        result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    assert result["testgen_has_pass_and_fail"] is False
+    assert result["testgen_composite_pass"] is False
+
+
+# ---------------------------------------------------------------------------
+# evaluate_testgen: mirror keys for existing reports
+# ---------------------------------------------------------------------------
+
+def test_mirror_keys_present(tmp_path):
+    suite_dir = _write_suite(tmp_path)
+    source = _write_source(tmp_path)
+    with patch("evaluators.testgen_validator.run_kyverno_test") as mock_kt:
+        mock_kt.return_value = (True, [], False)
+        result = evaluate_testgen(generated_dir=suite_dir, source_policy=source, oracle_dir=None)
+    for key in ("schema_pass", "semantic_pass", "semantic_skipped", "semantic_errors"):
+        assert key in result, f"mirror key {key!r} missing from result"

--- a/evaluators/testgen_validator.py
+++ b/evaluators/testgen_validator.py
@@ -117,7 +117,8 @@ def evaluate_testgen(
         schema_pass = False
 
     try:
-        yaml.safe_load(resources_path.read_text(encoding="utf-8"))
+        # resources.yaml typically contains multiple documents separated by ---
+        list(yaml.safe_load_all(resources_path.read_text(encoding="utf-8")))
     except Exception as exc:
         errors.append(f"Failed to parse resources.yaml: {exc}")
         schema_pass = False

--- a/evaluators/testgen_validator.py
+++ b/evaluators/testgen_validator.py
@@ -1,0 +1,197 @@
+"""Evaluation of AI-generated Kyverno CLI test suites.
+
+A test suite is a directory containing:
+  kyverno-test.yaml  — Test manifest (apiVersion: cli.kyverno.io/v1alpha1)
+  resources.yaml     — Resource manifests referenced by the test
+  policy.yaml        — Copy of the source policy (placed by the harness)
+
+Three evaluation layers:
+  1. Schema: files exist, YAML parses, required fields present
+  2. Functional: kyverno test exits zero
+  3. Coverage: generated vs oracle tuple counts, has_pass_and_fail
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+from .semantic_validator import run_kyverno_test
+
+_EXPECTED_API_VERSION = "cli.kyverno.io/v1alpha1"
+_EXPECTED_KIND = "Test"
+_REQUIRED_FIELDS = ("policies", "resources", "results")
+
+
+def _count_tuples(results: list[dict]) -> int:
+    """Count individual (resource_name, result) pairs across all result entries."""
+    total = 0
+    for entry in results:
+        resources = entry.get("resources") or []
+        total += len(resources) if resources else 1
+    return total
+
+
+def _has_pass_and_fail(results: list[dict]) -> bool:
+    outcomes = {str(r.get("result", "")).lower() for r in results}
+    return "pass" in outcomes and "fail" in outcomes
+
+
+def _load_policy_meta(source_policy: Path) -> tuple[str | None, str]:
+    """Return (metadata.name, kind) from a policy YAML, or (None, '') on failure."""
+    if yaml is None or not source_policy.exists():
+        return None, ""
+    try:
+        doc = yaml.safe_load(source_policy.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict):
+            return None, ""
+        return (doc.get("metadata") or {}).get("name"), doc.get("kind", "")
+    except Exception:
+        return None, ""
+
+
+def evaluate_testgen(
+    *,
+    generated_dir: Path,
+    source_policy: Path,
+    oracle_dir: Path | None,
+    timeout_sec: int = 60,
+) -> dict:
+    """Evaluate an AI-generated Kyverno CLI test suite.
+
+    Returns a dict with keys:
+      schema_pass, semantic_pass, semantic_skipped     — mirrors for existing reports
+      testgen_schema_pass, testgen_kyverno_test_pass,
+      testgen_kyverno_test_skipped, testgen_coverage_score,
+      testgen_oracle_tuples, testgen_generated_tuples,
+      testgen_has_pass_and_fail, testgen_composite_pass, testgen_errors
+    """
+    errors: list[str] = []
+
+    # --- 1. Schema: file existence + YAML structure ---
+    test_manifest_path = generated_dir / "kyverno-test.yaml"
+    resources_path = generated_dir / "resources.yaml"
+
+    missing = [f.name for f in (test_manifest_path, resources_path) if not f.exists()]
+    if missing:
+        errors.append(f"Missing required files: {', '.join(missing)}")
+        return _failure_result(errors)
+
+    if yaml is None:
+        errors.append("PyYAML not installed; cannot validate test manifest")
+        return _failure_result(errors)
+
+    schema_pass = True
+    parsed_manifest: dict | None = None
+
+    try:
+        parsed_manifest = yaml.safe_load(test_manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(parsed_manifest, dict):
+            errors.append("kyverno-test.yaml is not a YAML mapping")
+            schema_pass = False
+        else:
+            actual_api = parsed_manifest.get("apiVersion")
+            if actual_api != _EXPECTED_API_VERSION:
+                errors.append(
+                    f"kyverno-test.yaml apiVersion must be {_EXPECTED_API_VERSION!r},"
+                    f" got {actual_api!r}"
+                )
+                schema_pass = False
+            actual_kind = parsed_manifest.get("kind")
+            if actual_kind != _EXPECTED_KIND:
+                errors.append(
+                    f"kyverno-test.yaml kind must be {_EXPECTED_KIND!r},"
+                    f" got {actual_kind!r}"
+                )
+                schema_pass = False
+            for field in _REQUIRED_FIELDS:
+                if not parsed_manifest.get(field):
+                    errors.append(f"kyverno-test.yaml missing required field: {field!r}")
+                    schema_pass = False
+    except Exception as exc:
+        errors.append(f"Failed to parse kyverno-test.yaml: {exc}")
+        schema_pass = False
+
+    try:
+        yaml.safe_load(resources_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        errors.append(f"Failed to parse resources.yaml: {exc}")
+        schema_pass = False
+
+    if not schema_pass:
+        return _failure_result(errors)
+
+    # --- 2. Functional: kyverno test ---
+    policy_name, policy_kind = _load_policy_meta(source_policy)
+    kt_passed, kt_errors, kt_skipped = run_kyverno_test(
+        generated_dir,
+        output_policy_name=policy_name,
+        output_policy_kind=policy_kind,
+        policy_under_test=source_policy,
+        timeout_sec=timeout_sec,
+    )
+
+    # --- 3. Coverage ---
+    generated_results: list[dict] = (parsed_manifest or {}).get("results") or []
+    generated_tuples = _count_tuples(generated_results)
+    has_p_and_f = _has_pass_and_fail(generated_results)
+
+    oracle_tuples = 0
+    if oracle_dir and yaml is not None:
+        oracle_manifest = oracle_dir / "kyverno-test.yaml"
+        if oracle_manifest.exists():
+            try:
+                oracle_doc = yaml.safe_load(oracle_manifest.read_text(encoding="utf-8"))
+                if isinstance(oracle_doc, dict):
+                    oracle_tuples = _count_tuples(oracle_doc.get("results") or [])
+            except Exception:
+                pass
+
+    coverage_score = (
+        min(generated_tuples / oracle_tuples, 1.0) if oracle_tuples > 0 else 0.0
+    )
+
+    # Composite requires structural validity, a runnable suite, and scenario diversity.
+    # Coverage score is reported but not gated — the oracle represents one author's
+    # choices, not a minimum bar.
+    composite = schema_pass and (kt_passed if not kt_skipped else False) and has_p_and_f
+
+    return {
+        "testgen_schema_pass": schema_pass,
+        "testgen_kyverno_test_pass": kt_passed if not kt_skipped else None,
+        "testgen_kyverno_test_skipped": kt_skipped,
+        "testgen_coverage_score": round(coverage_score, 4),
+        "testgen_oracle_tuples": oracle_tuples,
+        "testgen_generated_tuples": generated_tuples,
+        "testgen_has_pass_and_fail": has_p_and_f,
+        "testgen_composite_pass": composite,
+        "testgen_errors": errors + kt_errors,
+        # Mirrors for existing report rendering
+        "schema_pass": schema_pass,
+        "semantic_pass": kt_passed if not kt_skipped else None,
+        "semantic_skipped": kt_skipped,
+        "semantic_errors": kt_errors,
+    }
+
+
+def _failure_result(errors: list[str]) -> dict:
+    return {
+        "testgen_schema_pass": False,
+        "testgen_kyverno_test_pass": None,
+        "testgen_kyverno_test_skipped": True,
+        "testgen_coverage_score": 0.0,
+        "testgen_oracle_tuples": 0,
+        "testgen_generated_tuples": 0,
+        "testgen_has_pass_and_fail": False,
+        "testgen_composite_pass": False,
+        "testgen_errors": errors,
+        # Mirrors
+        "schema_pass": False,
+        "semantic_pass": None,
+        "semantic_skipped": True,
+        "semantic_errors": [],
+    }

--- a/evaluators/testgen_validator.py
+++ b/evaluators/testgen_validator.py
@@ -31,7 +31,7 @@ def _count_tuples(results: list[dict]) -> int:
     """Count individual (resource_name, result) pairs across all result entries."""
     total = 0
     for entry in results:
-        resources = entry.get("resources") or []
+        resources = entry.get("resources")
         total += len(resources) if resources else 1
     return total
 

--- a/reports/generate.py
+++ b/reports/generate.py
@@ -66,15 +66,15 @@ def _load_results(include_files: list[str] | None = None) -> list[dict]:
 
 
 def _deduplicate_runs(results: list[dict]) -> list[dict]:
-    """If multiple runs exist for the same (tool, policy_id), keep the best one.
+    """If multiple runs exist for the same (tool, policy_id, task_type), keep the best one.
 
     Prefers records that carry a ``runs`` array (multi-run aggregated data)
     over plain single-run records.  Among candidates of the same kind, the
     latest by ``timestamp`` wins.
     """
-    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    groups: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
     for r in results:
-        key = (r.get("tool", ""), r.get("policy_id", ""))
+        key = (r.get("tool", ""), r.get("policy_id", ""), r.get("task_type", "convert"))
         groups[key].append(r)
 
     def _best(runs: list[dict]) -> dict:

--- a/reports/generate.py
+++ b/reports/generate.py
@@ -345,7 +345,7 @@ def _compute_testgen_leaderboard(testgen_results: list[dict]) -> list[dict]:
     for tool, items in sorted(by_tool.items()):
         total = len(items)
         composite_pass = sum(1 for i in items if i.get("testgen_composite_pass"))
-        coverage_scores = [i["testgen_coverage_score"] for i in items if i.get("testgen_coverage_score") is not None]
+        coverage_scores = [i["testgen_coverage_score"] for i in items if i.get("testgen_oracle_tuples", 0) > 0]
         has_pf = sum(1 for i in items if i.get("testgen_has_pass_and_fail"))
         times = [i["conversion_time_seconds"] for i in items if i.get("conversion_time_seconds")]
         costs = [i["cost_usd"] for i in items if i.get("cost_usd") is not None]

--- a/reports/generate.py
+++ b/reports/generate.py
@@ -335,6 +335,34 @@ def _generate_tool_summaries(results: list[dict], tool_stats: dict) -> dict[str,
     return summaries
 
 
+def _compute_testgen_leaderboard(testgen_results: list[dict]) -> list[dict]:
+    """Per-tool stats for generate_test runs: composite pass, coverage, has_pass_and_fail."""
+    by_tool: dict[str, list[dict]] = defaultdict(list)
+    for r in testgen_results:
+        by_tool[r.get("tool", "unknown")].append(r)
+
+    board = []
+    for tool, items in sorted(by_tool.items()):
+        total = len(items)
+        composite_pass = sum(1 for i in items if i.get("testgen_composite_pass"))
+        coverage_scores = [i["testgen_coverage_score"] for i in items if i.get("testgen_coverage_score") is not None]
+        has_pf = sum(1 for i in items if i.get("testgen_has_pass_and_fail"))
+        times = [i["conversion_time_seconds"] for i in items if i.get("conversion_time_seconds")]
+        costs = [i["cost_usd"] for i in items if i.get("cost_usd") is not None]
+        board.append({
+            "tool": tool,
+            "total": total,
+            "composite_pass": composite_pass,
+            "composite_pass_rate": round(composite_pass / total, 4) if total else 0,
+            "avg_coverage": round(sum(coverage_scores) / len(coverage_scores), 4) if coverage_scores else 0,
+            "has_pass_and_fail": has_pf,
+            "avg_time": round(sum(times) / len(times), 2) if times else None,
+            "avg_cost": round(sum(costs) / len(costs), 6) if costs else None,
+        })
+    board.sort(key=lambda x: (-x["composite_pass_rate"], x["avg_time"] or float("inf")))
+    return board
+
+
 def _compute_leaderboard(tool_stats: dict, config: dict | None = None) -> list[dict]:
     """Rank tools by pass_rate. Speed, cost, diff reported as supplementary metrics."""
     board: list[dict] = []
@@ -393,6 +421,19 @@ def generate_markdown(agg: dict, leaderboard: list[dict]) -> str:
         t = f"{stats['avg_time']:.1f}s" if stats["avg_time"] else "-"
         lines.append(f"- **{tt}**: {_rate_str(stats)}, avg {t}")
 
+    testgen = [r for r in agg["results"] if r.get("task_type") == "generate_test"]
+    if testgen:
+        tg_board = _compute_testgen_leaderboard(testgen)
+        lines.append("\n## Kyverno CLI Test Generation\n")
+        lines.append(f"| {'Tool':<10} | {'Composite Pass':>14} | {'Avg Coverage':>12} | {'Has Pass+Fail':>13} | {'Avg Time':>8} |")
+        lines.append(f"|{'-'*12}|{'-'*16}|{'-'*14}|{'-'*15}|{'-'*10}|")
+        for e in tg_board:
+            t = f"{e['avg_time']:.1f}s" if e["avg_time"] else "-"
+            lines.append(
+                f"| {e['tool']:<10} | {e['composite_pass']:>5}/{e['total']:<8} | "
+                f"{e['avg_coverage']:>11.0%} | {e['has_pass_and_fail']:>5}/{e['total']:<7} | {t:>8} |"
+            )
+
     lines.append("\n## Per-Difficulty Breakdown\n")
     for diff, stats in agg.get("difficulty_stats", {}).items():
         t = f"{stats['avg_time']:.1f}s" if stats["avg_time"] else "-"
@@ -421,18 +462,21 @@ def generate_markdown(agg: dict, leaderboard: list[dict]) -> str:
 def generate_html(
     agg: dict, leaderboard: list[dict], config: dict | None = None
 ) -> str:
-    """Generate a self-contained HTML dashboard (combined + conversion + generation)."""
+    """Generate a self-contained HTML dashboard (combined + conversion + generation + test-gen)."""
     results_all = agg["results"]
     convert_results = [
         r for r in results_all if r.get("task_type", "convert") == "convert"
     ]
     generate_results = [r for r in results_all if r.get("task_type") == "generate"]
+    testgen_results = [r for r in results_all if r.get("task_type") == "generate_test"]
     convert_agg = _aggregate(convert_results)
     generate_agg = _aggregate(generate_results)
     leaderboard_convert = _compute_leaderboard(convert_agg["tool_stats"], config)
     leaderboard_generate = _compute_leaderboard(generate_agg["tool_stats"], config)
+    leaderboard_testgen = _compute_testgen_leaderboard(testgen_results)
     has_convert = bool(convert_results)
     has_generate = bool(generate_results)
+    has_testgen = bool(testgen_results)
 
     if Environment and TEMPLATES_DIR.exists():
         env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)))
@@ -443,10 +487,13 @@ def generate_html(
                 leaderboard=leaderboard,
                 leaderboard_convert=leaderboard_convert,
                 leaderboard_generate=leaderboard_generate,
+                leaderboard_testgen=leaderboard_testgen,
                 convert_results=convert_results,
                 generate_results=generate_results,
+                testgen_results=testgen_results,
                 has_convert=has_convert,
                 has_generate=has_generate,
+                has_testgen=has_testgen,
             )
         except Exception as exc:
             print(

--- a/reports/generate.py
+++ b/reports/generate.py
@@ -128,11 +128,11 @@ def _aggregate(results: list[dict]) -> dict:
     by_output_kind: dict[str, list[dict]] = defaultdict(list)
     by_task_type: dict[str, list[dict]] = defaultdict(list)
     for r in results:
-        by_tool[r.get("tool", "unknown")].append(r)
-        by_track[r.get("track", "unknown")].append(r)
-        by_difficulty[r.get("difficulty", "unknown")].append(r)
-        by_output_kind[r.get("expected_output_kind", "unknown")].append(r)
-        by_task_type[r.get("task_type", "convert")].append(r)
+        by_tool[r.get("tool") or "unknown"].append(r)
+        by_track[r.get("track") or "unknown"].append(r)
+        by_difficulty[r.get("difficulty") or "unknown"].append(r)
+        by_output_kind[r.get("expected_output_kind") or "unknown"].append(r)
+        by_task_type[r.get("task_type") or "convert"].append(r)
 
     def _stats(items: list[dict]) -> dict:
         total = len(items)

--- a/reports/templates/dashboard.html.j2
+++ b/reports/templates/dashboard.html.j2
@@ -239,6 +239,36 @@
   </div>
 </div>
 
+{# ---- Kyverno CLI Test Generation leaderboard ---- #}
+{% if has_testgen is defined and has_testgen %}
+<div class="leaderboard" style="margin-top:1.5rem;">
+  <h2>Kyverno CLI Test Generation</h2>
+  <p style="font-size:0.8rem;color:var(--muted);margin:0.25rem 0 0.75rem;">Composite pass = schema valid <em>and</em> <code>kyverno test</code> exits 0 <em>and</em> suite has both pass and fail cases. Coverage score = generated tuples / oracle tuples (capped at 1.0, not gated).</p>
+  <div class="table-scroll">
+  <table class="lb-table">
+    <tr>
+      <th>Tool</th>
+      <th>Composite Pass</th>
+      <th>Avg Coverage</th>
+      <th>Has Pass+Fail</th>
+      <th>Avg Time</th>
+      <th>Avg Cost</th>
+    </tr>
+    {% for e in leaderboard_testgen %}
+    <tr>
+      <td class="tool-name">{{ e.tool }}</td>
+      <td class="metric">{{ e.composite_pass }}<span class="metric-label"> / {{ e.total }}</span></td>
+      <td class="metric">{{ "%.0f" | format(e.avg_coverage * 100) }}%</td>
+      <td class="metric">{{ e.has_pass_and_fail }}<span class="metric-label"> / {{ e.total }}</span></td>
+      <td class="metric">{{ "%.1f" | format(e.avg_time) if e.avg_time else "-" }}{{ "s" if e.avg_time else "" }}</td>
+      <td class="metric">{{ "$%.4f" | format(e.avg_cost) if e.avg_cost else "-" }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+  </div>
+</div>
+{% endif %}
+
 {# ---- Charts ---- #}
 <div class="charts">
   <div class="chart-card">
@@ -360,6 +390,12 @@ function renderRunDetail(run, parent) {
   if (r.cost_usd != null) metrics.push({ label: 'Cost', value: '$' + r.cost_usd.toFixed(4) });
   if (r.total_tokens != null) metrics.push({ label: 'Tokens', value: r.total_tokens.toLocaleString() });
   if (r.model) metrics.push({ label: 'Model', value: r.model });
+  if (r.task_type === 'generate_test') {
+    if (r.testgen_coverage_score != null) metrics.push({ label: 'Coverage', value: (r.testgen_coverage_score * 100).toFixed(0) + '%' });
+    if (r.testgen_has_pass_and_fail != null) metrics.push({ label: 'Pass+Fail Cases', value: r.testgen_has_pass_and_fail ? 'yes' : 'no' });
+    if (r.testgen_generated_tuples != null) metrics.push({ label: 'Generated Tuples', value: r.testgen_generated_tuples });
+    if (r.testgen_oracle_tuples) metrics.push({ label: 'Oracle Tuples', value: r.testgen_oracle_tuples });
+  }
 
   document.getElementById('modalMetrics').innerHTML = metrics.map(m =>
     '<div class="metric-chip"><span class="mc-label">' + esc(m.label) + '</span><span class="mc-value">' + esc(m.value) + '</span></div>'

--- a/run_tool_cursor.sh
+++ b/run_tool_cursor.sh
@@ -4,6 +4,9 @@
 #   <source-policy-path> is "none" for generation tasks.
 #   Exit 0 on success, 1 on failure.
 #   The converted/generated policy must be written to <output-path>.
+#   For generate_test tasks, BENCH_OUTPUT_KIND=dir is set and OUTPUT is a
+#   directory that already contains policy.yaml; the tool should write
+#   kyverno-test.yaml and resources.yaml into it.
 #
 # Requires: Cursor Team/Pro plan. Install CLI: curl https://cursor.com/install | bash
 # Auth: agent login (one-time browser auth)
@@ -17,13 +20,24 @@ REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 # Use CURSOR_BIN env var if set, otherwise fall back to PATH
 AGENT="${CURSOR_BIN:-agent}"
 
-mkdir -p "$(dirname "$OUTPUT")"
+if [ "${BENCH_OUTPUT_KIND:-file}" = "dir" ]; then
+  mkdir -p "$OUTPUT"
+else
+  mkdir -p "$(dirname "$OUTPUT")"
+fi
 
 "$AGENT" -p "$PROMPT" \
   --model claude-4.6-sonnet-medium \
   --force 2>&1
 
-if [ ! -f "$OUTPUT" ]; then
-  echo "ERROR: Cursor agent did not produce output at $OUTPUT" >&2
-  exit 1
+if [ "${BENCH_OUTPUT_KIND:-file}" = "dir" ]; then
+  if [ ! -f "${OUTPUT}/kyverno-test.yaml" ]; then
+    echo "ERROR: Cursor agent did not produce kyverno-test.yaml in $OUTPUT" >&2
+    exit 1
+  fi
+else
+  if [ ! -f "$OUTPUT" ]; then
+    echo "ERROR: Cursor agent did not produce output at $OUTPUT" >&2
+    exit 1
+  fi
 fi

--- a/run_tool_nctl.sh
+++ b/run_tool_nctl.sh
@@ -4,6 +4,9 @@
 #   <source-policy-path> is "none" for generation tasks.
 #   Exit 0 on success, 1 on failure.
 #   The converted/generated policy must be written to <output-path>.
+#   For generate_test tasks, BENCH_OUTPUT_KIND=dir is set and OUTPUT is a
+#   directory that already contains policy.yaml; the tool should write
+#   kyverno-test.yaml and resources.yaml into it.
 set -euo pipefail
 
 SOURCE="$1"
@@ -14,7 +17,11 @@ REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 # Use NCTL_BIN env var if set, otherwise fall back to PATH
 NCTL="${NCTL_BIN:-nctl}"
 
-mkdir -p "$(dirname "$OUTPUT")"
+if [ "${BENCH_OUTPUT_KIND:-file}" = "dir" ]; then
+  mkdir -p "$OUTPUT"
+else
+  mkdir -p "$(dirname "$OUTPUT")"
+fi
 
 "$NCTL" ai \
   --provider bedrock \
@@ -23,7 +30,14 @@ mkdir -p "$(dirname "$OUTPUT")"
   --prompt "$PROMPT" \
   --skip-permission-checks 2>&1
 
-if [ ! -f "$OUTPUT" ]; then
-  echo "ERROR: nctl did not produce output at $OUTPUT" >&2
-  exit 1
+if [ "${BENCH_OUTPUT_KIND:-file}" = "dir" ]; then
+  if [ ! -f "${OUTPUT}/kyverno-test.yaml" ]; then
+    echo "ERROR: nctl did not produce kyverno-test.yaml in $OUTPUT" >&2
+    exit 1
+  fi
+else
+  if [ ! -f "$OUTPUT" ]; then
+    echo "ERROR: nctl did not produce output at $OUTPUT" >&2
+    exit 1
+  fi
 fi

--- a/runners/base.py
+++ b/runners/base.py
@@ -62,6 +62,20 @@ def extract_yaml_block(text: str) -> str | None:
     return None
 
 
+def dir_output_artifact(output_path: Path) -> Path | None:
+    """Return the canonical artifact for directory-output tasks, or None.
+
+    For generate_test tasks, benchmark.py pre-creates ``output_path`` as a
+    directory containing ``policy.yaml``.  The AI should write
+    ``kyverno-test.yaml`` and ``resources.yaml`` there.  Checking
+    ``output_path.exists()`` is always True; callers need the specific file.
+
+    Returns ``None`` for single-file (convert/generate) tasks so callers can
+    use the compact pattern: ``output_check = dir_output_artifact(p) or p``.
+    """
+    return (output_path / "kyverno-test.yaml") if output_path.is_dir() else None
+
+
 # -----------------------------------------------------------------------
 # Centralized model pricing (USD per 1M tokens: input, output)
 # -----------------------------------------------------------------------
@@ -207,15 +221,12 @@ def run_cli_subprocess(
     except (_json.JSONDecodeError, TypeError):
         pass
 
-    # For directory-output tasks the harness pre-creates output_path, so
-    # output_path.exists() is vacuously True.  Use output_check_path (the
-    # canonical artifact inside the directory) for the real existence test.
-    _check = output_check_path if output_check_path is not None else output_path
+    artifact = output_check_path if output_check_path is not None else output_path
 
     # -- Determine success / YAML fallback ---------------------------------
-    success = proc.returncode == 0 and _check.exists()
+    success = proc.returncode == 0 and artifact.exists()
 
-    if proc.returncode == 0 and not _check.exists() and output_check_path is None:
+    if proc.returncode == 0 and not artifact.exists() and output_check_path is None:
         # YAML extraction only applies to single-file (convert/generate) output.
         yaml_text = extract_yaml_block(raw_text)
         if yaml_text:
@@ -231,9 +242,9 @@ def run_cli_subprocess(
         output_tokens = real_output_tokens
     else:
         out_text = ""
-        if _check.is_file():
+        if artifact.is_file():
             try:
-                out_text = _check.read_text(encoding="utf-8")
+                out_text = artifact.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError) as exc:
                 print(f"  Warning: could not read output file: {exc}", file=sys.stderr)
         output_tokens = estimate_tokens(out_text)
@@ -257,7 +268,7 @@ def run_cli_subprocess(
         error=None if success else (
             f"{cmd[0]} CLI exited {proc.returncode}"
             if proc.returncode != 0
-            else f"{cmd[0]} exited 0 but did not write output to {_check}"
+            else f"{cmd[0]} exited 0 but did not write output to {artifact}"
         ),
         model=model_name,
         tool_version=tool_version,

--- a/runners/base.py
+++ b/runners/base.py
@@ -131,6 +131,7 @@ def run_cli_subprocess(
     default_model: str,
     tool_version: str | None,
     raw_log_builder: Callable[[str, str], str | None] | None = None,
+    output_check_path: Path | None = None,
 ) -> RunResult:
     """Run a CLI tool as a subprocess and build a RunResult.
 
@@ -148,7 +149,7 @@ def run_cli_subprocess(
     full_prompt : str
         The prompt sent to the tool (used for token estimation fallback).
     output_path : Path
-        Where the converted policy should be written.
+        Where the converted policy (or test-suite directory) should be written.
     timeout : int
         Subprocess timeout in seconds.
     default_model : str
@@ -158,6 +159,12 @@ def run_cli_subprocess(
     raw_log_builder : callable | None
         Optional function ``(stdout: str, stderr: str) -> str`` to build the
         raw_log field.  Defaults to ``stdout[:5000]``.
+    output_check_path : Path | None
+        For directory-output tasks (generate_test), the harness pre-creates
+        ``output_path`` as a directory, so ``output_path.exists()`` is always
+        True.  Pass the canonical artifact (e.g. ``output_path /
+        "kyverno-test.yaml"``) here so the success check and token estimation
+        target the right file.  Defaults to ``output_path`` (file-output mode).
     """
     repo_root = Path(__file__).resolve().parent.parent
 
@@ -200,10 +207,16 @@ def run_cli_subprocess(
     except (_json.JSONDecodeError, TypeError):
         pass
 
-    # -- Determine success / YAML fallback ---------------------------------
-    success = proc.returncode == 0 and output_path.exists()
+    # For directory-output tasks the harness pre-creates output_path, so
+    # output_path.exists() is vacuously True.  Use output_check_path (the
+    # canonical artifact inside the directory) for the real existence test.
+    _check = output_check_path if output_check_path is not None else output_path
 
-    if proc.returncode == 0 and not output_path.exists():
+    # -- Determine success / YAML fallback ---------------------------------
+    success = proc.returncode == 0 and _check.exists()
+
+    if proc.returncode == 0 and not _check.exists() and output_check_path is None:
+        # YAML extraction only applies to single-file (convert/generate) output.
         yaml_text = extract_yaml_block(raw_text)
         if yaml_text:
             output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -218,9 +231,9 @@ def run_cli_subprocess(
         output_tokens = real_output_tokens
     else:
         out_text = ""
-        if output_path.exists():
+        if _check.is_file():
             try:
-                out_text = output_path.read_text(encoding="utf-8")
+                out_text = _check.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError) as exc:
                 print(f"  Warning: could not read output file: {exc}", file=sys.stderr)
         output_tokens = estimate_tokens(out_text)

--- a/runners/base.py
+++ b/runners/base.py
@@ -254,7 +254,11 @@ def run_cli_subprocess(
         output_path=output_path,
         conversion_time_seconds=round(elapsed, 3),
         success=success,
-        error=None if success else f"{cmd[0]} CLI exited {proc.returncode}",
+        error=None if success else (
+            f"{cmd[0]} CLI exited {proc.returncode}"
+            if proc.returncode != 0
+            else f"{cmd[0]} exited 0 but did not write output to {_check}"
+        ),
         model=model_name,
         tool_version=tool_version,
         input_tokens=input_tokens,

--- a/runners/claude_runner.py
+++ b/runners/claude_runner.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from .base import (
     RunResult,
     ToolRunner,
+    dir_output_artifact,
     extract_yaml_block,
     model_cost,
     run_cli_subprocess,
@@ -55,22 +56,20 @@ class ClaudeRunner(ToolRunner):
         prompt: str,
         timeout_seconds: int,
     ) -> RunResult:
-        is_dir_output = output_path.is_dir()
+        output_check_path = dir_output_artifact(output_path)
 
-        if is_dir_output:
+        if output_check_path is not None:
             full_prompt = (
                 f"{prompt}\n\n"
                 f"The policy file is already at: {output_path / 'policy.yaml'}\n"
                 f"Write kyverno-test.yaml and resources.yaml to: {output_path}"
             )
-            output_check_path: Path | None = output_path / "kyverno-test.yaml"
         else:
             full_prompt = (
                 f"{prompt}\n\n"
                 f"The source policy file is at: {input_path}\n"
                 f"Write the converted policy to: {output_path}"
             )
-            output_check_path = None
 
         cmd = [
             "claude",

--- a/runners/claude_runner.py
+++ b/runners/claude_runner.py
@@ -55,11 +55,22 @@ class ClaudeRunner(ToolRunner):
         prompt: str,
         timeout_seconds: int,
     ) -> RunResult:
-        full_prompt = (
-            f"{prompt}\n\n"
-            f"The source policy file is at: {input_path}\n"
-            f"Write the converted policy to: {output_path}"
-        )
+        is_dir_output = output_path.is_dir()
+
+        if is_dir_output:
+            full_prompt = (
+                f"{prompt}\n\n"
+                f"The policy file is already at: {output_path / 'policy.yaml'}\n"
+                f"Write kyverno-test.yaml and resources.yaml to: {output_path}"
+            )
+            output_check_path: Path | None = output_path / "kyverno-test.yaml"
+        else:
+            full_prompt = (
+                f"{prompt}\n\n"
+                f"The source policy file is at: {input_path}\n"
+                f"Write the converted policy to: {output_path}"
+            )
+            output_check_path = None
 
         cmd = [
             "claude",
@@ -76,6 +87,7 @@ class ClaudeRunner(ToolRunner):
             timeout=timeout_seconds,
             default_model="claude-code-cli",
             tool_version=_get_claude_version(),
+            output_check_path=output_check_path,
         )
 
     # ------------------------------------------------------------------
@@ -89,6 +101,14 @@ class ClaudeRunner(ToolRunner):
         model: str,
         timeout_seconds: int,
     ) -> RunResult:
+        if output_path.is_dir():
+            return RunResult(
+                output_path=output_path,
+                conversion_time_seconds=0,
+                success=False,
+                error="generate_test tasks require the Claude CLI; API mode cannot write multiple files",
+            )
+
         try:
             import anthropic
         except ImportError:

--- a/runners/nctl_runner.py
+++ b/runners/nctl_runner.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from .base import (
     RunResult,
     ToolRunner,
+    dir_output_artifact,
     estimate_cost,
     estimate_tokens,
 )
@@ -69,8 +70,8 @@ class NctlRunner(ToolRunner):
 
         repo_root = Path(__file__).resolve().parent.parent
         version = self._get_version()
-        is_dir_output = output_path.is_dir()
-        if not is_dir_output:
+        output_check = dir_output_artifact(output_path)
+        if output_check is None:
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
         cmd = [
@@ -102,7 +103,7 @@ class NctlRunner(ToolRunner):
             )
 
         log = (proc.stdout or "") + "\n" + (proc.stderr or "")
-        output_check = (output_path / "kyverno-test.yaml") if is_dir_output else output_path
+        output_check = output_check or output_path
         success = (
             proc.returncode == 0
             and output_check.exists()

--- a/runners/nctl_runner.py
+++ b/runners/nctl_runner.py
@@ -69,7 +69,9 @@ class NctlRunner(ToolRunner):
 
         repo_root = Path(__file__).resolve().parent.parent
         version = self._get_version()
-        output_path.parent.mkdir(parents=True, exist_ok=True)
+        is_dir_output = output_path.is_dir()
+        if not is_dir_output:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
 
         cmd = [
             nctl_bin, "ai",
@@ -100,18 +102,19 @@ class NctlRunner(ToolRunner):
             )
 
         log = (proc.stdout or "") + "\n" + (proc.stderr or "")
+        output_check = (output_path / "kyverno-test.yaml") if is_dir_output else output_path
         success = (
             proc.returncode == 0
-            and output_path.exists()
+            and output_check.exists()
             and self._AGENT_OK in log
         )
 
         # --- step 4: estimate tokens (nctl doesn't expose real counts) ---
         input_toks = estimate_tokens(prompt)
         output_text = ""
-        if output_path.exists():
+        if output_check.is_file():
             try:
-                output_text = output_path.read_text(encoding="utf-8")
+                output_text = output_check.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError) as exc:
                 print(f"  Warning: could not read output file: {exc}", file=sys.stderr)
         output_toks = estimate_tokens(output_text)

--- a/runners/prompts.py
+++ b/runners/prompts.py
@@ -2,9 +2,10 @@
 
 Every benchmark run uses these prompts so results are comparable across tools.
 
-Two categories:
+Three categories:
   - **Conversion** prompts: parameterized by track + expected output kind.
   - **Generation** prompts: natural-language description → write a new policy.
+  - **Test-generation** prompts: existing policy → write kyverno-test.yaml + resources.yaml.
 """
 
 from __future__ import annotations
@@ -83,6 +84,33 @@ _DOCS_CLAUSE = (
     "\n- https://github.com/kyverno/kyverno-policies"
 )
 
+_TESTGEN_DOCS_CLAUSE = (
+    f"\n\nLook up Kyverno {KYVERNO_VERSION} documentation and examples before writing the test:"
+    "\n- https://kyverno.io/docs/writing-policies/testing/"
+    "\n- https://github.com/kyverno/kyverno-policies"
+)
+
+# ---------------------------------------------------------------------------
+# Test-generation prompt (existing policy → kyverno-test.yaml + resources.yaml)
+# ---------------------------------------------------------------------------
+
+_TESTGEN_PROMPT = (
+    "Write a Kyverno CLI test suite for the Kyverno policy in {input_path}. "
+    "Create two files in {output_path}:\n"
+    "1. `kyverno-test.yaml` — apiVersion: cli.kyverno.io/v1alpha1, kind: Test, "
+    "with `policies: [policy.yaml]` (the policy is already copied there as policy.yaml).\n"
+    "2. `resources.yaml` — all Kubernetes resource manifests referenced by the test cases.\n\n"
+    "Requirements:\n"
+    "- Cover both passing cases (resources the policy allows) "
+    "and failing cases (resources the policy denies or flags).\n"
+    "- For new-style policy kinds (ValidatingPolicy, MutatingPolicy, GeneratingPolicy, "
+    "DeletingPolicy, NamespacedDeletingPolicy, ImageValidatingPolicy): set "
+    "`isValidatingPolicy: true` on each result entry and OMIT the `rule:` field.\n"
+    "- For ClusterPolicy: include the `rule:` field matching the exact rule name.\n"
+    "- Each result entry must include: `policy` (the policy metadata.name), `kind`, "
+    "`resources` (list of resource names from resources.yaml), `result` (pass or fail)."
+)
+
 
 def build_prompt(
     track: str,
@@ -98,10 +126,20 @@ def build_prompt(
 
     For *convert* tasks, looks up the template by (track, output_kind).
     For *generate* tasks, uses the generation template with *description*.
+    For *generate_test* tasks, uses the test-generation template.
 
     When *include_docs* is True, appends a clause pointing the tool at the
     canonical Kyverno docs and the community policy repo.
     """
+    if task_type == "generate_test":
+        prompt = _TESTGEN_PROMPT.format(
+            input_path=input_path or "the provided policy",
+            output_path=output_path,
+        )
+        if include_docs:
+            prompt += _TESTGEN_DOCS_CLAUSE
+        return prompt
+
     if task_type == "generate":
         prompt = _GENERATION_PROMPT.format(
             kyverno_version=KYVERNO_VERSION,

--- a/runners/script_runner.py
+++ b/runners/script_runner.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from .base import (
     RunResult,
     ToolRunner,
+    dir_output_artifact,
     estimate_cost,
     estimate_tokens,
 )
@@ -57,9 +58,10 @@ class ScriptRunner(ToolRunner):
     ) -> RunResult:
         repo_root = Path(__file__).resolve().parent.parent
 
-        # output_path is a pre-created directory for generate_test tasks.
-        # Detect this before touching the filesystem.
-        is_dir_output = output_path.is_dir()
+        # dir_output_artifact returns a path if output_path is a pre-created
+        # directory (generate_test tasks), None for single-file tasks.
+        output_check = dir_output_artifact(output_path)
+        is_dir_output = output_check is not None
         if not is_dir_output:
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -89,10 +91,7 @@ class ScriptRunner(ToolRunner):
             )
 
         log = (proc.stdout or "") + "\n" + (proc.stderr or "")
-
-        # For directory output, the directory itself is pre-created; check the
-        # canonical artifact to confirm the tool actually produced something.
-        output_check = (output_path / "kyverno-test.yaml") if is_dir_output else output_path
+        output_check = output_check or output_path
         success = proc.returncode == 0 and output_check.exists()
 
         # Read optional sidecar metadata

--- a/runners/script_runner.py
+++ b/runners/script_runner.py
@@ -7,8 +7,12 @@ Any tool can be benchmarked by providing a script that follows this contract:
     # The converted/generated policy must be written to <output-path>.
     # <source-policy-path> is "none" for generation tasks.
 
+For generate_test tasks, BENCH_OUTPUT_KIND=dir is set in the subprocess
+environment and <output-path> is a pre-created directory.  The script should
+write kyverno-test.yaml and resources.yaml into it.
+
 After the script exits, the harness:
-  - Checks for the output file
+  - Checks for the output file (or kyverno-test.yaml in dir mode)
   - Reads an optional sidecar <output-path>.meta.json for real token counts:
       {"input_tokens": N, "output_tokens": N, "model": "...", "tool_version": "..."}
   - Falls back to heuristic token estimation if no sidecar is found
@@ -18,6 +22,7 @@ After the script exits, the harness:
 from __future__ import annotations
 
 import json as _json
+import os
 import subprocess
 import sys
 import time
@@ -51,11 +56,18 @@ class ScriptRunner(ToolRunner):
         config: dict | None = None,
     ) -> RunResult:
         repo_root = Path(__file__).resolve().parent.parent
-        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # output_path is a pre-created directory for generate_test tasks.
+        # Detect this before touching the filesystem.
+        is_dir_output = output_path.is_dir()
+        if not is_dir_output:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
 
         source_arg = str(input_path) if input_path and input_path.is_file() else "none"
-
         cmd = [str(self._script), source_arg, str(output_path), prompt]
+
+        # Signal dir-output mode to the shell script via environment variable.
+        env = {**os.environ, "BENCH_OUTPUT_KIND": "dir" if is_dir_output else "file"}
 
         start = time.monotonic()
         try:
@@ -65,6 +77,7 @@ class ScriptRunner(ToolRunner):
                 text=True,
                 timeout=timeout_seconds,
                 cwd=str(repo_root),
+                env=env,
             )
             elapsed = time.monotonic() - start
         except subprocess.TimeoutExpired:
@@ -76,7 +89,11 @@ class ScriptRunner(ToolRunner):
             )
 
         log = (proc.stdout or "") + "\n" + (proc.stderr or "")
-        success = proc.returncode == 0 and output_path.exists()
+
+        # For directory output, the directory itself is pre-created; check the
+        # canonical artifact to confirm the tool actually produced something.
+        output_check = (output_path / "kyverno-test.yaml") if is_dir_output else output_path
+        success = proc.returncode == 0 and output_check.exists()
 
         # Read optional sidecar metadata
         meta_path = Path(str(output_path) + ".meta.json")
@@ -105,9 +122,9 @@ class ScriptRunner(ToolRunner):
             input_tokens = estimate_tokens(prompt)
         if output_tokens is None:
             out_text = ""
-            if output_path.exists():
+            if output_check.is_file():
                 try:
-                    out_text = output_path.read_text(encoding="utf-8")
+                    out_text = output_check.read_text(encoding="utf-8")
                 except (OSError, UnicodeDecodeError) as exc:
                     print(f"  Warning: could not read output file: {exc}", file=sys.stderr)
             output_tokens = estimate_tokens(out_text)

--- a/scripts/merge_runs.py
+++ b/scripts/merge_runs.py
@@ -5,7 +5,7 @@ Usage:
   python3 scripts/merge_runs.py results/run1/benchmark_*.json results/run2/benchmark_*.json ...
   python3 scripts/merge_runs.py results/run*/benchmark_*.json
 
-Reads the aggregated benchmark JSON from each run, groups by (tool, policy_id),
+Reads the aggregated benchmark JSON from each run, groups by (tool, policy_id, task_type),
 and produces a merged JSON where each entry has:
   - pass_rate: mean of successes across runs (0.0, 0.333, 0.667, 1.0 for 3 runs)
   - n_runs_aggregated: number of runs merged
@@ -38,8 +38,8 @@ SHARED_FIELDS = {
 
 def merge(run_files: list[Path]) -> list[dict]:
     """Merge multiple run files into a single results list."""
-    # Group all entries by (tool, policy_id)
-    by_key: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    # Group all entries by (tool, policy_id, task_type)
+    by_key: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
 
     for run_file in run_files:
         data = json.loads(run_file.read_text(encoding="utf-8"))
@@ -47,11 +47,11 @@ def merge(run_files: list[Path]) -> list[dict]:
             print(f"  Warning: {run_file} is not a list, skipping", file=sys.stderr)
             continue
         for entry in data:
-            key = (entry["tool"], entry["policy_id"])
+            key = (entry["tool"], entry["policy_id"], entry.get("task_type", "convert"))
             by_key[key].append(entry)
 
     merged: list[dict] = []
-    for (tool, policy_id), entries in sorted(by_key.items()):
+    for (tool, policy_id, _task_type), entries in sorted(by_key.items()):
         n_runs = len(entries)
         pass_per_run = [e.get("success", False) for e in entries]
         pass_rate = round(sum(1 for p in pass_per_run if p) / n_runs, 4)


### PR DESCRIPTION
## Summary

- Adds a new `generate_test` task type that benchmarks AI tools on generating a runnable `kyverno-test.yaml` + `resources.yaml` test suite for an existing Kyverno policy
- 6 policies in the cycle-1 dataset spanning CP-validate (single/multi-rule), CP-mutate, CP-generate, and native ValidatingPolicy
- Three evaluation layers: schema validity → `kyverno test` functional pass → coverage (generated vs oracle tuples, has both pass and fail cases)
- Composite pass = schema AND kyverno test AND has_pass_and_fail; coverage score reported but not gated

## What changed

**New**
- `evaluators/testgen_validator.py` — three-layer evaluator with 18 unit tests
- `runners/base.py` — `dir_output_artifact()` helper + `output_check_path` param on `run_cli_subprocess` for directory-output tasks
- `dataset/kyverno-upstream-manifest.yaml` — `vpol_block_ephemeral_containers` native ValidatingPolicy fixture
- 6 `tg_*` entries in `dataset/index.yaml`

**Modified**
- `benchmark.py` — `generate_test` task type wiring: directory output setup, `policy.yaml` copy into output dir, `evaluate_testgen()` routing, `--task-type generate_test` flag
- `runners/prompts.py` — `_TESTGEN_PROMPT` template with `isValidatingPolicy` / no-`rule` guidance for new-style kinds
- `runners/{claude,script,nctl}_runner.py`, `run_tool_{nctl,cursor}.sh` — `BENCH_OUTPUT_KIND=dir` env signal, output existence checks target `kyverno-test.yaml` not the pre-created directory
- `reports/generate.py` — testgen leaderboard (composite pass, avg coverage, has_pass_and_fail) + `None`-safe grouping for `expected_output_kind: null`
- `reports/templates/dashboard.html.j2` — testgen leaderboard section + modal metrics for coverage/tuple counts
- `config.yaml` — `generate_test` task type registered
- `scripts/merge_runs.py`, `reports/generate.py` — dedup key `(tool, policy_id, task_type)` to prevent silent collision when same policy appears under two task types

## Smoke test results (claude, all 6 policies)

```
claude  tg_cp_require_labels               PASS  (schema+CEL: PASS, functional: PASS)
claude  tg_cp_disallow_default_namespace   PASS
claude  tg_cp_require_drop_all            FAIL  (exited 0 but did not write output)
claude  tg_cp_inject_sidecar              FAIL  (exited 0 but did not write output)
claude  tg_cp_kasten_generate_backup      FAIL  (exited 0 but did not write output)
claude  tg_vpol_block_ephemeral_containers PASS
```

3/6 on first run. Failures are Claude generating a planning response instead of using Write tool on complex/hard policies — legitimate benchmark signal, not a framework bug. Framework correctly detects and reports them.

## Test plan

- [x] 18 unit tests pass (`pytest evaluators/test_testgen_validator.py`)
- [x] `python3 benchmark.py --task-type generate_test --tool claude --policy tg_cp_require_labels` → PASS
- [x] All 6 testgen policies smoke-tested with claude
- [x] Existing convert path regression check: `--policy cp_require_labels --tool claude` → PASS
- [x] Dashboard generates without errors (testgen leaderboard section renders)
- [x] `/simplify` review applied — `dir_output_artifact` helper, coverage filter fix, `_count_tuples` cleanup