### PR TITLE
chore: ignore .gitnexus code intelligence index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ dataset/.cache/
 dataset/imported/**
 !dataset/imported/README.md
 !dataset/imported/upstream-meta.json
+.gitnexus


### PR DESCRIPTION
## Summary

- Adds `.gitnexus` to `.gitignore` to prevent the GitNexus local code intelligence index from being accidentally committed

## Test plan

- [ ] Verify `.gitnexus/` does not appear in `git status` after running `npx gitnexus analyze`